### PR TITLE
[ feat ] 직군/직무, 희망 근무지, 희망 연봉 선택사항 서버에 저장되는 기능 추가

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -5,6 +5,12 @@ DB_PASSWORD=your_password
 DB_DATABASE=good_job_test
 
 # ---------------------------------------------------------------------------------------
+# 개발환경 시
+NODE_ENV=development
+# 운영환경 배포 시
+#NODE_ENV=production
+
+# ---------------------------------------------------------------------------------------
 # 구글 OAuth 클라이언트 정보
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=

--- a/src/onboarding/jobs/jobs.module.ts
+++ b/src/onboarding/jobs/jobs.module.ts
@@ -1,7 +1,7 @@
 import { Module } from '@nestjs/common';
 import { JobsController } from './jobs.controller';
 import { JobsService } from './jobs.service';
-import { DatabaseModule } from '../database/database.module';
+import { DatabaseModule } from '../../database/database.module';
 
 @Module({
     imports: [DatabaseModule], // 데이터베이스 연결을 위해 임포트

--- a/src/onboarding/jobs/jobs.service.ts
+++ b/src/onboarding/jobs/jobs.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { DatabaseService } from '../database/database.service';
+import { DatabaseService } from '../../database/database.service';
 
 @Injectable()
 export class JobsService {

--- a/src/onboarding/locations/locations.module.ts
+++ b/src/onboarding/locations/locations.module.ts
@@ -1,7 +1,7 @@
 import { Module } from '@nestjs/common';
 import { LocationsController } from './locations.controller';
 import { LocationsService } from './locations.service';
-import { DatabaseModule } from '../database/database.module';
+import { DatabaseModule } from '../../database/database.module';
 
 @Module({
     imports: [DatabaseModule],

--- a/src/onboarding/locations/locations.service.ts
+++ b/src/onboarding/locations/locations.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { DatabaseService } from '../database/database.service';
+import { DatabaseService } from '../../database/database.service';
 
 @Injectable()
 export class LocationsService {

--- a/src/onboarding/profile/profile.module.ts
+++ b/src/onboarding/profile/profile.module.ts
@@ -1,7 +1,7 @@
 import { Module } from '@nestjs/common';
 import { ProfileController } from './profile.controller';
 import { ProfileService } from './profile.service';
-import { DatabaseModule } from '../database/database.module';
+import { DatabaseModule } from '../../database/database.module';
 
 @Module({
     imports: [DatabaseModule],

--- a/src/onboarding/profile/profile.service.ts
+++ b/src/onboarding/profile/profile.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
-import { DatabaseService } from '../database/database.service';
+import { DatabaseService } from '../../database/database.service';
 
 @Injectable()
 export class ProfileService {

--- a/src/onboarding/salaries/salaries.module.ts
+++ b/src/onboarding/salaries/salaries.module.ts
@@ -1,7 +1,7 @@
 import { Module } from '@nestjs/common';
 import { SalariesController } from './salaries.controller';
 import { SalariesService } from './salaries.service';
-import { DatabaseModule } from '../database/database.module';
+import { DatabaseModule } from '../../database/database.module';
 
 @Module({
     imports: [DatabaseModule],

--- a/src/onboarding/salaries/salaries.service.ts
+++ b/src/onboarding/salaries/salaries.service.ts
@@ -1,39 +1,39 @@
 import { Injectable } from '@nestjs/common';
-import { DatabaseService } from '../database/database.service';
+import { DatabaseService } from '../../database/database.service';
 
 @Injectable()
 export class SalariesService {
     constructor(private readonly databaseService: DatabaseService) {}
 
-      // 모든 연봉 구간 조회
-  async getAllSalaryRanges() {
-    const query = `
+    // 모든 연봉 구간 조회
+    async getAllSalaryRanges() {
+        const query = `
       SELECT idx, min_salary, display_text 
       FROM salary_range 
       ORDER BY min_salary ASC
     `;
-    return await this.databaseService.query(query);
-  }
+        return await this.databaseService.query(query);
+    }
 
-  // 특정 연봉 구간 조회
-  async getSalaryRangeById(id: number) {
-    const query = `
+    // 특정 연봉 구간 조회
+    async getSalaryRangeById(id: number) {
+        const query = `
       SELECT idx, min_salary, display_text 
       FROM salary_range 
       WHERE idx = ?
     `;
-    const result = await this.databaseService.query(query, [id]);
-    return result[0] || null;
-  }
+        const result = await this.databaseService.query(query, [id]);
+        return result[0] || null;
+    }
 
-  // 연봉 구간 검색 (최소 연봉 기준)
-  async getSalaryRangesByMinSalary(minSalary: number) {
-    const query = `
+    // 연봉 구간 검색 (최소 연봉 기준)
+    async getSalaryRangesByMinSalary(minSalary: number) {
+        const query = `
       SELECT idx, min_salary, display_text 
       FROM salary_range 
       WHERE min_salary >= ?
       ORDER BY min_salary ASC
     `;
-    return await this.databaseService.query(query, [minSalary]);
-  }
+        return await this.databaseService.query(query, [minSalary]);
+    }
 }

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -1,7 +1,19 @@
-import { Controller, Get, Query } from '@nestjs/common';
+import { Controller, Get, Query, Post, Body, Req, HttpException, HttpStatus } from '@nestjs/common';
 import { DatabaseService } from '../database/database.service';
+import { z } from 'zod';
+import type { Request } from 'express';
 
-@Controller('users')
+interface AuthenticatedRequest extends Request {
+    user_idx: number;
+}
+
+// 직군/직무 선호도 저장 요청 스키마
+const JobPreferenceSchema = z.object({
+    categoryId: z.number().int().positive('직군 ID는 양수여야 합니다'),
+    roleId: z.number().int().positive('직무 ID는 양수여야 합니다'),
+});
+
+@Controller('user')
 export class UsersController {
     constructor(private readonly databaseService: DatabaseService) {}
 
@@ -30,6 +42,95 @@ export class UsersController {
                 error: error instanceof Error ? error.message : 'Unknown error',
                 message: '사용자 목록 조회에 실패했습니다.',
             };
+        }
+    }
+
+    /**
+     * 사용자 직군/직무 선호도 저장
+     * POST /user/job-preference
+     */
+    @Post('job-preference')
+    async saveUserJobPreference(@Body() body: unknown, @Req() req: AuthenticatedRequest) {
+        try {
+            // 요청 데이터 유효성 검사
+            const parsed = JobPreferenceSchema.safeParse(body);
+            if (!parsed.success) {
+                throw new HttpException(
+                    {
+                        success: false,
+                        error: '유효하지 않은 요청 데이터입니다.',
+                        details: parsed.error.flatten(),
+                    },
+                    HttpStatus.BAD_REQUEST,
+                );
+            }
+
+            const { categoryId, roleId } = parsed.data;
+            const userId = req.user_idx;
+
+            if (!userId) {
+                throw new HttpException(
+                    {
+                        success: false,
+                        error: '사용자 인증이 필요합니다.',
+                    },
+                    HttpStatus.UNAUTHORIZED,
+                );
+            }
+
+            // 직무가 해당 직군에 속하는지 확인
+            const roleValidationQuery = `
+                SELECT id FROM job_role 
+                WHERE id = ? AND category_id = ?
+            `;
+            const roleValidation = await this.databaseService.query(roleValidationQuery, [
+                roleId,
+                categoryId,
+            ]);
+
+            if (roleValidation.length === 0) {
+                throw new HttpException(
+                    {
+                        success: false,
+                        error: '선택한 직무가 해당 직군에 속하지 않습니다.',
+                    },
+                    HttpStatus.BAD_REQUEST,
+                );
+            }
+
+            // individual_profile 테이블에 저장 (UPSERT)
+            // 임시로 기본값 사용 (서울특별시, 강남구, 기본 연봉)
+            const upsertQuery = `
+                INSERT INTO individual_profile (user_idx, desired_job, desired_sido, desired_gu, desired_salary)
+                VALUES (?, ?, '11', '11680', 1)
+                ON DUPLICATE KEY UPDATE 
+                    desired_job = VALUES(desired_job)
+            `;
+
+            await this.databaseService.query(upsertQuery, [userId, roleId]);
+
+            return {
+                success: true,
+                message: '직군/직무 선호도가 성공적으로 저장되었습니다.',
+                data: {
+                    userId,
+                    categoryId,
+                    roleId,
+                },
+            };
+        } catch (error) {
+            if (error instanceof HttpException) {
+                throw error;
+            }
+
+            console.error('직군/직무 선호도 저장 오류:', error);
+            throw new HttpException(
+                {
+                    success: false,
+                    error: '직군/직무 선호도 저장에 실패했습니다.',
+                },
+                HttpStatus.INTERNAL_SERVER_ERROR,
+            );
         }
     }
 }

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -13,6 +13,17 @@ const JobPreferenceSchema = z.object({
     roleId: z.number().int().positive('직무 ID는 양수여야 합니다'),
 });
 
+// 희망 근무지 선호도 저장 요청 스키마
+const LocationPreferenceSchema = z.object({
+    sidoCode: z.string().length(2, '시도 코드는 2자리여야 합니다'),
+    guCode: z.string().length(5, '구/군 코드는 5자리여야 합니다'),
+});
+
+// 희망 연봉 선호도 저장 요청 스키마
+const SalaryPreferenceSchema = z.object({
+    salaryRangeId: z.number().int().positive('연봉 구간 ID는 양수여야 합니다'),
+});
+
 @Controller('user')
 export class UsersController {
     constructor(private readonly databaseService: DatabaseService) {}
@@ -128,6 +139,197 @@ export class UsersController {
                 {
                     success: false,
                     error: '직군/직무 선호도 저장에 실패했습니다.',
+                },
+                HttpStatus.INTERNAL_SERVER_ERROR,
+            );
+        }
+    }
+
+    /**
+     * 사용자 희망 근무지 선호도 저장
+     * POST /user/location-preference
+     */
+    @Post('location-preference')
+    async saveUserLocationPreference(@Body() body: unknown, @Req() req: AuthenticatedRequest) {
+        try {
+            // 요청 데이터 유효성 검사
+            const parsed = LocationPreferenceSchema.safeParse(body);
+            if (!parsed.success) {
+                throw new HttpException(
+                    {
+                        success: false,
+                        error: '유효하지 않은 요청 데이터입니다.',
+                        details: parsed.error.flatten(),
+                    },
+                    HttpStatus.BAD_REQUEST,
+                );
+            }
+
+            const { sidoCode, guCode } = parsed.data;
+            const userId = req.user_idx;
+
+            if (!userId) {
+                throw new HttpException(
+                    {
+                        success: false,
+                        error: '사용자 인증이 필요합니다.',
+                    },
+                    HttpStatus.UNAUTHORIZED,
+                );
+            }
+
+            // 시도 코드 유효성 검사
+            const sidoValidationQuery = `
+                SELECT sido_code FROM sido WHERE sido_code = ?
+            `;
+            const sidoValidation = await this.databaseService.query(sidoValidationQuery, [
+                sidoCode,
+            ]);
+
+            if (sidoValidation.length === 0) {
+                throw new HttpException(
+                    {
+                        success: false,
+                        error: '유효하지 않은 시도 코드입니다.',
+                    },
+                    HttpStatus.BAD_REQUEST,
+                );
+            }
+
+            // 구/군 코드 유효성 검사 (해당 시도에 속하는지 확인)
+            const guValidationQuery = `
+                SELECT gu_code FROM gu WHERE gu_code = ? AND sido_code = ?
+            `;
+            const guValidation = await this.databaseService.query(guValidationQuery, [
+                guCode,
+                sidoCode,
+            ]);
+
+            if (guValidation.length === 0) {
+                throw new HttpException(
+                    {
+                        success: false,
+                        error: '선택한 구/군이 해당 시도에 속하지 않습니다.',
+                    },
+                    HttpStatus.BAD_REQUEST,
+                );
+            }
+
+            // individual_profile 테이블에 희망 근무지 업데이트
+            const updateQuery = `
+                UPDATE individual_profile 
+                SET desired_sido = ?, desired_gu = ?
+                WHERE user_idx = ?
+            `;
+
+            await this.databaseService.query(updateQuery, [sidoCode, guCode, userId]);
+
+            return {
+                success: true,
+                message: '희망 근무지 선호도가 성공적으로 저장되었습니다.',
+                data: {
+                    userId,
+                    sidoCode,
+                    guCode,
+                },
+            };
+        } catch (error) {
+            if (error instanceof HttpException) {
+                throw error;
+            }
+
+            console.error('희망 근무지 선호도 저장 오류:', error);
+            throw new HttpException(
+                {
+                    success: false,
+                    error: '희망 근무지 선호도 저장에 실패했습니다.',
+                },
+                HttpStatus.INTERNAL_SERVER_ERROR,
+            );
+        }
+    }
+
+    /**
+     * 사용자 희망 연봉 선호도 저장
+     * POST /user/salary-preference
+     */
+    @Post('salary-preference')
+    async saveUserSalaryPreference(@Body() body: unknown, @Req() req: AuthenticatedRequest) {
+        try {
+            // 요청 데이터 유효성 검사
+            const parsed = SalaryPreferenceSchema.safeParse(body);
+            if (!parsed.success) {
+                throw new HttpException(
+                    {
+                        success: false,
+                        error: '유효하지 않은 요청 데이터입니다.',
+                        details: parsed.error.flatten(),
+                    },
+                    HttpStatus.BAD_REQUEST,
+                );
+            }
+
+            const { salaryRangeId } = parsed.data;
+            const userId = req.user_idx;
+
+            if (!userId) {
+                throw new HttpException(
+                    {
+                        success: false,
+                        error: '인증이 필요합니다.',
+                    },
+                    HttpStatus.UNAUTHORIZED,
+                );
+            }
+
+            // 연봉 구간 존재 여부 확인
+            const salaryCheckQuery = `
+                SELECT idx FROM salary_range 
+                WHERE idx = ?
+            `;
+            const salaryExists = await this.databaseService.query(salaryCheckQuery, [
+                salaryRangeId,
+            ]);
+
+            if (salaryExists.length === 0) {
+                throw new HttpException(
+                    {
+                        success: false,
+                        error: '존재하지 않는 연봉 구간입니다.',
+                    },
+                    HttpStatus.BAD_REQUEST,
+                );
+            }
+
+            // individual_profile 테이블에 저장 (UPSERT)
+            // 임시로 기본값 사용 (서울특별시, 강남구, 기본 직무)
+            const upsertQuery = `
+                INSERT INTO individual_profile (user_idx, desired_job, desired_sido, desired_gu, desired_salary)
+                VALUES (?, 1, '11', '11680', ?)
+                ON DUPLICATE KEY UPDATE 
+                    desired_salary = VALUES(desired_salary)
+            `;
+
+            await this.databaseService.query(upsertQuery, [userId, salaryRangeId]);
+
+            return {
+                success: true,
+                message: '희망 연봉 선호도가 성공적으로 저장되었습니다.',
+                data: {
+                    userId,
+                    salaryRangeId,
+                },
+            };
+        } catch (error) {
+            if (error instanceof HttpException) {
+                throw error;
+            }
+
+            console.error('Error saving salary preference:', error);
+            throw new HttpException(
+                {
+                    success: false,
+                    error: '희망 연봉 선호도 저장 중 오류가 발생했습니다.',
                 },
                 HttpStatus.INTERNAL_SERVER_ERROR,
             );


### PR DESCRIPTION
Feature/gj 119 

- 로그인 후 사용자 선호도 선택 단계에 서버 저장 기능을 추가했습니다.
- `individual_profile` 테이블에 사용자 선호도 저장됩니다.
- UPSERT 방식으로 구현했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 인증된 사용자 선호도 저장 API 추가: 직무/역할, 지역, 급여. 입력 유효성 검증과 표준화된 오류 응답 제공. 기존 조회 기능은 유지. 엔드포인트 기본 경로를 /user로 정리.
- Documentation
  - .env.sample에 개발/프로덕션 환경 안내 추가(NODE_ENV 예시 포함).
- Refactor
  - 내부 모듈 경로를 정리하여 구조 일관성 개선(기능 변화 없음).
- Style
  - 일부 코드 포매팅 정리로 가독성 향상.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->