### PR TITLE
[ feat ] 프로필 이미지 업로드 기능 구현

### DIFF
--- a/src/onboarding/profile/profile.controller.ts
+++ b/src/onboarding/profile/profile.controller.ts
@@ -1,7 +1,20 @@
-import { Controller, Get, Put, Body, Req, UnauthorizedException } from '@nestjs/common';
+import {
+    Controller,
+    Get,
+    Put,
+    Post,
+    Body,
+    Req,
+    UnauthorizedException,
+    UseInterceptors,
+    UploadedFile,
+    BadRequestException,
+} from '@nestjs/common';
+import { FileInterceptor } from '@nestjs/platform-express';
 import type { Request } from 'express';
 import * as jwt from 'jsonwebtoken';
 import { ProfileService } from './profile.service';
+import { uploadFileToS3, validateImageFile, generateS3Key } from '../../lib/s3';
 
 @Controller('profile')
 export class ProfileController {
@@ -16,10 +29,50 @@ export class ProfileController {
     @Put('me')
     async updateProfile(
         @Req() req: Request,
-        @Body() updateData: { short_bio?: string; bio?: string },
+        @Body() updateData: { short_bio?: string; bio?: string; profile_img?: string },
     ) {
         const userId = this.getUserIdFromToken(req);
         return this.profileService.updateProfile(userId, updateData);
+    }
+
+    @Post('upload-image')
+    @UseInterceptors(FileInterceptor('image'))
+    async uploadProfileImage(@Req() req: Request, @UploadedFile() file: Express.Multer.File) {
+        const userId = this.getUserIdFromToken(req);
+
+        // 파일 유효성 검사
+        const validation = validateImageFile(file);
+        if (!validation.isValid) {
+            throw new BadRequestException(validation.error);
+        }
+
+        try {
+            // S3 키 생성
+            const s3Key = generateS3Key(file.originalname, 'profile-images');
+
+            // S3에 이미지 업로드
+            const uploadResult = await uploadFileToS3(file.buffer, s3Key, file.mimetype);
+
+            if (!uploadResult.success) {
+                throw new BadRequestException(`이미지 업로드 실패: ${uploadResult.error}`);
+            }
+
+            // 프로필에 이미지 URL 저장
+            await this.profileService.updateProfile(userId, {
+                profile_img: uploadResult.url,
+            });
+
+            return {
+                success: true,
+                message: '프로필 이미지가 업로드되었습니다.',
+                imageUrl: uploadResult.url,
+            };
+        } catch (error) {
+            if (error instanceof BadRequestException) {
+                throw error;
+            }
+            throw new BadRequestException('이미지 업로드 중 오류가 발생했습니다.');
+        }
     }
 
     private getUserIdFromToken(req: Request): number {

--- a/src/onboarding/profile/profile.service.ts
+++ b/src/onboarding/profile/profile.service.ts
@@ -5,7 +5,10 @@ import { DatabaseService } from '../../database/database.service';
 export class ProfileService {
     constructor(private readonly databaseService: DatabaseService) {}
 
-    async updateProfile(userId: number, updateData: { short_bio?: string; bio?: string }) {
+    async updateProfile(
+        userId: number,
+        updateData: { short_bio?: string; bio?: string; profile_img?: string },
+    ) {
         // 사용자 존재 여부 확인
         const existingUsers = await this.databaseService.query(
             'SELECT idx FROM users WHERE idx = ?',
@@ -30,6 +33,11 @@ export class ProfileService {
             updateValues.push(updateData.bio);
         }
 
+        if (updateData.profile_img !== undefined) {
+            updateFields.push('profile_img = ?');
+            updateValues.push(updateData.profile_img);
+        }
+
         if (updateFields.length === 0) {
             throw new Error('업데이트할 필드가 없습니다.');
         }
@@ -47,7 +55,7 @@ export class ProfileService {
 
         // 업데이트된 프로필 조회
         const updatedUsers = await this.databaseService.query(
-            'SELECT idx, name, phone, email, short_bio, bio, created_at, updated_at FROM users WHERE idx = ?',
+            'SELECT idx, name, phone, email, short_bio, bio, profile_img, created_at, updated_at FROM users WHERE idx = ?',
             [userId],
         );
 


### PR DESCRIPTION
- S3를 통한 프로필 이미지 업로드 API 추가 
(이미지 파일 자체는 S3에 저장되고, 데이터베이스에는 S3 URL만 저장)
- 프로필 업데이터 API에 profile_img 필드 추가
- 프론트엔드 프로필 입력 페이지 구현