### PR TITLE
[ feat ] 이력서 CRUD 관련 기능 추가 (조회 기능만 검증 완료)

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -20,6 +20,7 @@ import { SalariesModule } from './onboarding/salaries/salaries.module';
 import { ProfileModule } from './onboarding/profile/profile.module';
 import { SessionGuard } from './auth/session.guard';
 // resume
+import { ResumeModule } from './resume/resume.module';
 import { CanvasModule } from './modules/coaching-resume/canvas.modeule';
 
 /* stt 모듈 */
@@ -50,6 +51,7 @@ import { TTSModule } from './tts/tts.module';
         CanvasModule,
         SocialModule,
         TTSModule,
+        ResumeModule,
     ],
     controllers: [AppController, STTController],
     providers: [

--- a/src/database/database.service.ts
+++ b/src/database/database.service.ts
@@ -112,6 +112,11 @@ export class DatabaseService implements OnModuleInit, OnModuleDestroy {
         }
     }
 
+    async queryOne<T = any>(sql: string, params?: any[]): Promise<T | null> {
+        const results = await this.query<T>(sql, params);
+        return results.length > 0 ? results[0] : null;
+    }
+
     async queryWithSort<T = any>(
         sql: string,
         params?: any[],

--- a/src/resume/dto/create-resume.dto.ts
+++ b/src/resume/dto/create-resume.dto.ts
@@ -1,0 +1,11 @@
+// dto/create-resume.dto.ts
+import { IsString, IsNotEmpty, MaxLength, IsOptional } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class CreateResumeDto {
+    @ApiProperty({ description: '이력서 제목', example: '프론트엔드 개발자 이력서' })
+    @IsString()
+    @IsNotEmpty()
+    @MaxLength(255)
+    title: string;
+}

--- a/src/resume/dto/resume-detail-response.dto.ts
+++ b/src/resume/dto/resume-detail-response.dto.ts
@@ -1,0 +1,91 @@
+// dto/resume-detail-response.dto.ts
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ResumeCareerDto {
+    @ApiProperty({ description: '경력 ID' })
+    careerId: number;
+
+    @ApiProperty({ description: '회사명' })
+    companyName: string;
+
+    @ApiProperty({ description: '포지션' })
+    position: string;
+
+    @ApiProperty({ description: '현재 재직 중 여부' })
+    isCurrent: boolean;
+
+    @ApiProperty({ description: '입사일', nullable: true })
+    startDate: Date | null;
+
+    @ApiProperty({ description: '퇴사일', nullable: true })
+    endDate: Date | null;
+
+    @ApiProperty({ description: '업무 설명' })
+    description: string;
+}
+
+export class ResumeSkillDto {
+    @ApiProperty({ description: '스킬 ID' })
+    skillId: number;
+
+    @ApiProperty({ description: '스킬명' })
+    skillName: string;
+}
+
+export class ResumeEducationDto {
+    @ApiProperty({ description: '학력 ID' })
+    educationId: number;
+
+    @ApiProperty({ description: '학교명' })
+    schoolName: string;
+
+    @ApiProperty({ description: '전공' })
+    major: string;
+
+    @ApiProperty({ description: '학위' })
+    degree: string;
+
+    @ApiProperty({ description: '입학일', nullable: true })
+    startDate: Date | null;
+
+    @ApiProperty({ description: '졸업일', nullable: true })
+    endDate: Date | null;
+
+    @ApiProperty({ description: '재학 중 여부' })
+    isCurrent: boolean;
+}
+
+export class ResumeDetailResponseDto {
+    @ApiProperty({ description: '이력서 ID' })
+    resumeId: number;
+
+    @ApiProperty({ description: '사용자 ID' })
+    userId: number;
+
+    @ApiProperty({ description: '이력서 제목' })
+    title: string;
+
+    @ApiProperty({ description: '생성일' })
+    createdAt: Date;
+
+    @ApiProperty({ description: '수정일' })
+    updatedAt: Date;
+
+    @ApiProperty({ description: '경력 목록', type: [ResumeCareerDto] })
+    careers: ResumeCareerDto[];
+
+    @ApiProperty({ description: '스킬 목록', type: [ResumeSkillDto] })
+    skills: ResumeSkillDto[];
+
+    @ApiProperty({ description: '학력 목록', type: [ResumeEducationDto] })
+    educations: ResumeEducationDto[];
+
+    @ApiProperty({ description: '경험/활동 목록' })
+    experiences: any[];
+
+    @ApiProperty({ description: '자기소개서 목록' })
+    coverletters: any[];
+
+    @ApiProperty({ description: '포트폴리오 목록' })
+    portfolios: any[];
+}

--- a/src/resume/dto/resume-list-response.dto.ts
+++ b/src/resume/dto/resume-list-response.dto.ts
@@ -1,0 +1,29 @@
+// dto/resume-list-response.dto.ts
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ResumeListResponseDto {
+    @ApiProperty({ description: '이력서 ID', example: 1 })
+    id: number;
+
+    @ApiProperty({ description: '이력서 제목', example: '프론트엔드 개발자 이력서' })
+    title: string;
+
+    @ApiProperty({ description: '포지션', example: 'Frontend Developer' })
+    position: string;
+
+    @ApiProperty({ description: '회사명', example: 'TechCorp' })
+    company: string;
+
+    @ApiProperty({ description: '생성일', example: '2024-01-15' })
+    createdAt: string;
+
+    @ApiProperty({ description: '총 경력', example: '3년' })
+    experience: string;
+
+    @ApiProperty({
+        description: '보유 기술 목록',
+        example: ['React', 'TypeScript', 'Next.js', 'Tailwind CSS'],
+        type: [String],
+    })
+    skills: string[];
+}

--- a/src/resume/dto/update-resume.dto.ts
+++ b/src/resume/dto/update-resume.dto.ts
@@ -1,0 +1,5 @@
+// dto/update-resume.dto.ts
+import { PartialType } from '@nestjs/swagger';
+import { CreateResumeDto } from './create-resume.dto';
+
+export class UpdateResumeDto extends PartialType(CreateResumeDto) {}

--- a/src/resume/interfaces/resume.interface.ts
+++ b/src/resume/interfaces/resume.interface.ts
@@ -1,0 +1,67 @@
+// interfaces/resume.interface.ts
+export interface Resume {
+    resume_id: number;
+    user_id: number;
+    title: string;
+    created_at: Date;
+    updated_at: Date;
+}
+
+export interface ResumeCareer {
+    career_id: number;
+    resume_id: number;
+    company_name: string;
+    position: string;
+    is_current: boolean;
+    start_date: Date | null;
+    end_date: Date | null;
+    description: string | null;
+}
+
+export interface ResumeSkill {
+    skill_id: number;
+    resume_id: number;
+    skill_name: string;
+}
+
+export interface ResumeEducation {
+    education_id: number;
+    resume_id: number;
+    school_name: string;
+    major: string;
+    degree: string;
+    start_date: Date | null;
+    end_date: Date | null;
+    is_current: boolean;
+}
+
+export interface ResumeExperience {
+    experience_id: number;
+    resume_id: number;
+    experience_name: string;
+    start_date: Date | null;
+    end_date: Date | null;
+    description: string | null;
+}
+
+export interface ResumeCoverletter {
+    coverletter_id: number;
+    resume_id: number;
+    coverletter_title: string | null;
+    description: string | null;
+}
+
+export interface ResumePortfolio {
+    portfolio_id: number;
+    resume_id: number;
+    link: string | null;
+}
+
+export interface ResumeWithDetails extends Resume {
+    careers: ResumeCareer[];
+    skills: ResumeSkill[];
+    educations: ResumeEducation[];
+    experiences: ResumeExperience[];
+    coverletters: ResumeCoverletter[];
+    portfolios: ResumePortfolio[];
+}

--- a/src/resume/resume.controller.ts
+++ b/src/resume/resume.controller.ts
@@ -1,0 +1,88 @@
+import {
+    Controller,
+    Get,
+    Post,
+    Body,
+    Patch,
+    Param,
+    Delete,
+    UseGuards,
+    Req,
+    ParseIntPipe,
+} from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth, ApiParam } from '@nestjs/swagger';
+import { ResumeService } from './resume.service';
+import { CreateResumeDto } from './dto/create-resume.dto';
+import { UpdateResumeDto } from './dto/update-resume.dto';
+import { ResumeListResponseDto } from './dto/resume-list-response.dto';
+import { ResumeDetailResponseDto } from './dto/resume-detail-response.dto';
+
+@ApiTags('Resume')
+@Controller('resumes')
+export class ResumeController {
+    constructor(private readonly resumeService: ResumeService) {}
+
+    @Post()
+    @ApiOperation({ summary: '새 이력서 생성' })
+    @ApiResponse({ status: 201, description: '이력서가 성공적으로 생성되었습니다.' })
+    @ApiResponse({ status: 400, description: '잘못된 요청입니다.' })
+    async create(@Body() createResumeDto: CreateResumeDto, @Req() req: any) {
+        // 실제로는 JWT 토큰에서 userId를 가져와야 함
+        const userId = req.user?.id || 1; // 임시로 하드코딩
+        return this.resumeService.create(createResumeDto, userId);
+    }
+
+    @Get('user/:userId')
+    @ApiOperation({ summary: '특정 사용자의 이력서 목록 조회' })
+    @ApiParam({ name: 'userId', description: '사용자 ID', type: 'number' })
+    @ApiResponse({
+        status: 200,
+        description: '이력서 목록을 성공적으로 조회했습니다.',
+        type: [ResumeListResponseDto],
+    })
+    @ApiResponse({ status: 404, description: '사용자를 찾을 수 없습니다.' })
+    async findByUserId(
+        @Param('userId', ParseIntPipe) userId: number,
+    ): Promise<ResumeListResponseDto[]> {
+        return this.resumeService.findByUserId(userId);
+    }
+
+    @Get(':id')
+    @ApiOperation({ summary: '특정 이력서 상세 조회' })
+    @ApiParam({ name: 'id', description: '이력서 ID', type: 'number' })
+    @ApiResponse({
+        status: 200,
+        description: '이력서를 성공적으로 조회했습니다.',
+        type: ResumeDetailResponseDto,
+    })
+    @ApiResponse({ status: 404, description: '이력서를 찾을 수 없습니다.' })
+    async findOne(@Param('id', ParseIntPipe) id: number): Promise<ResumeDetailResponseDto> {
+        return this.resumeService.findOne(id);
+    }
+
+    @Patch(':id')
+    @ApiOperation({ summary: '이력서 수정' })
+    @ApiParam({ name: 'id', description: '이력서 ID', type: 'number' })
+    @ApiResponse({ status: 200, description: '이력서가 성공적으로 수정되었습니다.' })
+    @ApiResponse({ status: 404, description: '이력서를 찾을 수 없습니다.' })
+    @ApiResponse({ status: 403, description: '권한이 없습니다.' })
+    async update(
+        @Param('id', ParseIntPipe) id: number,
+        @Body() updateResumeDto: UpdateResumeDto,
+        @Req() req: any,
+    ) {
+        const userId = req.user?.id || 1; // 임시로 하드코딩
+        return this.resumeService.update(id, updateResumeDto, userId);
+    }
+
+    @Delete(':id')
+    @ApiOperation({ summary: '이력서 삭제' })
+    @ApiParam({ name: 'id', description: '이력서 ID', type: 'number' })
+    @ApiResponse({ status: 200, description: '이력서가 성공적으로 삭제되었습니다.' })
+    @ApiResponse({ status: 404, description: '이력서를 찾을 수 없습니다.' })
+    @ApiResponse({ status: 403, description: '권한이 없습니다.' })
+    async remove(@Param('id', ParseIntPipe) id: number, @Req() req: any) {
+        const userId = req.user?.id || 1; // 임시로 하드코딩
+        return this.resumeService.remove(id, userId);
+    }
+}

--- a/src/resume/resume.module.ts
+++ b/src/resume/resume.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { ResumeController } from './resume.controller';
+import { ResumeService } from './resume.service';
+import { DatabaseModule } from '../database/database.module';
+
+@Module({
+    imports: [DatabaseModule],
+    controllers: [ResumeController],
+    providers: [ResumeService],
+    exports: [ResumeService],
+})
+export class ResumeModule {}

--- a/src/resume/resume.service.ts
+++ b/src/resume/resume.service.ts
@@ -1,0 +1,298 @@
+import {
+    Injectable,
+    NotFoundException,
+    ForbiddenException,
+    BadRequestException,
+} from '@nestjs/common';
+import { DatabaseService } from '../database/database.service';
+import { CreateResumeDto } from './dto/create-resume.dto';
+import { UpdateResumeDto } from './dto/update-resume.dto';
+import { ResumeListResponseDto } from './dto/resume-list-response.dto';
+import { ResumeDetailResponseDto } from './dto/resume-detail-response.dto';
+import {
+    Resume,
+    ResumeCareer,
+    ResumeSkill,
+    ResumeEducation,
+    ResumeWithDetails,
+} from './interfaces/resume.interface';
+
+@Injectable()
+export class ResumeService {
+    constructor(private readonly databaseService: DatabaseService) {}
+
+    async create(createResumeDto: CreateResumeDto, userId: number): Promise<Resume> {
+        try {
+            const sql = `
+        INSERT INTO resume (user_id, title, created_at, updated_at) 
+        VALUES (?, ?, NOW(), NOW())
+      `;
+
+            await this.databaseService.query(sql, [userId, createResumeDto.title]);
+
+            // 생성된 이력서 조회
+            const selectSql = `
+        SELECT * FROM resume 
+        WHERE user_id = ? AND title = ? 
+        ORDER BY created_at DESC 
+        LIMIT 1
+      `;
+
+            const resume = await this.databaseService.queryOne<Resume>(selectSql, [
+                userId,
+                createResumeDto.title,
+            ]);
+
+            if (!resume) {
+                throw new BadRequestException('이력서 생성에 실패했습니다.');
+            }
+
+            return resume;
+        } catch (error) {
+            throw new BadRequestException('이력서 생성에 실패했습니다.');
+        }
+    }
+
+    async findByUserId(userId: number): Promise<ResumeListResponseDto[]> {
+        try {
+            const sql = `
+        SELECT 
+          r.resume_id,
+          r.title,
+          r.created_at,
+          r.updated_at,
+          GROUP_CONCAT(DISTINCT rc.company_name ORDER BY rc.start_date DESC) as companies,
+          GROUP_CONCAT(DISTINCT rc.position ORDER BY rc.start_date DESC) as positions,
+          GROUP_CONCAT(DISTINCT rs.skill_name) as skills
+        FROM resume r
+        LEFT JOIN resume_career rc ON r.resume_id = rc.resume_id
+        LEFT JOIN resume_skill rs ON r.resume_id = rs.resume_id
+        WHERE r.user_id = ?
+        GROUP BY r.resume_id
+        ORDER BY r.updated_at DESC
+      `;
+
+            const resumes = await this.databaseService.query(sql, [userId]);
+
+            return resumes.map((resume) => this.transformToListResponse(resume));
+        } catch (error) {
+            throw new BadRequestException('이력서 목록 조회에 실패했습니다.');
+        }
+    }
+
+    async findOne(id: number): Promise<ResumeDetailResponseDto> {
+        try {
+            // 기본 이력서 정보 조회
+            const resumeSql = `SELECT * FROM resume WHERE resume_id = ?`;
+            const resume = await this.databaseService.queryOne<Resume>(resumeSql, [id]);
+
+            if (!resume) {
+                throw new NotFoundException('이력서를 찾을 수 없습니다.');
+            }
+
+            // 경력 정보 조회
+            const careerSql = `
+        SELECT * FROM resume_career 
+        WHERE resume_id = ? 
+        ORDER BY start_date DESC
+      `;
+            const careers = await this.databaseService.query<ResumeCareer>(careerSql, [id]);
+
+            // 스킬 정보 조회
+            const skillSql = `SELECT * FROM resume_skill WHERE resume_id = ?`;
+            const skills = await this.databaseService.query<ResumeSkill>(skillSql, [id]);
+
+            // 학력 정보 조회
+            const educationSql = `
+        SELECT * FROM resume_education 
+        WHERE resume_id = ? 
+        ORDER BY start_date DESC
+      `;
+            const educations = await this.databaseService.query<ResumeEducation>(educationSql, [
+                id,
+            ]);
+
+            // 경험/활동 정보 조회
+            const experienceSql = `
+        SELECT * FROM resume_experience 
+        WHERE resume_id = ? 
+        ORDER BY start_date DESC
+      `;
+            const experiences = await this.databaseService.query(experienceSql, [id]);
+
+            // 자기소개서 조회
+            const coverletterSql = `SELECT * FROM resume_coverletter WHERE resume_id = ?`;
+            const coverletters = await this.databaseService.query(coverletterSql, [id]);
+
+            // 포트폴리오 조회
+            const portfolioSql = `SELECT * FROM resume_portfolio WHERE resume_id = ?`;
+            const portfolios = await this.databaseService.query(portfolioSql, [id]);
+
+            return {
+                resumeId: resume.resume_id,
+                userId: resume.user_id,
+                title: resume.title,
+                createdAt: resume.created_at,
+                updatedAt: resume.updated_at,
+                careers: careers.map((career) => ({
+                    careerId: career.career_id,
+                    companyName: career.company_name,
+                    position: career.position,
+                    isCurrent: !!career.is_current,
+                    startDate: career.start_date,
+                    endDate: career.end_date,
+                    description: career.description ?? '',
+                })),
+                skills: skills.map((skill) => ({
+                    skillId: skill.skill_id,
+                    skillName: skill.skill_name,
+                })),
+                educations: educations.map((education) => ({
+                    educationId: education.education_id,
+                    schoolName: education.school_name,
+                    major: education.major,
+                    degree: education.degree,
+                    startDate: education.start_date,
+                    endDate: education.end_date,
+                    isCurrent: !!education.is_current,
+                })),
+                experiences: experiences.map((experience) => ({
+                    experienceId: experience.experience_id,
+                    experienceName: experience.experience_name,
+                    startDate: experience.start_date,
+                    endDate: experience.end_date,
+                    description: experience.description,
+                })),
+                coverletters: coverletters.map((coverletter) => ({
+                    coverletterId: coverletter.coverletter_id,
+                    coverletterTitle: coverletter.coverletter_title,
+                    description: coverletter.description,
+                })),
+                portfolios: portfolios.map((portfolio) => ({
+                    portfolioId: portfolio.portfolio_id,
+                    link: portfolio.link,
+                })),
+            };
+        } catch (error) {
+            if (error instanceof NotFoundException) {
+                throw error;
+            }
+            throw new BadRequestException('이력서 조회에 실패했습니다.');
+        }
+    }
+
+    async update(id: number, updateResumeDto: UpdateResumeDto, userId: number): Promise<Resume> {
+        try {
+            // 이력서 소유권 확인
+            const checkSql = `SELECT user_id FROM resume WHERE resume_id = ?`;
+            const resume = await this.databaseService.queryOne<{ user_id: number }>(checkSql, [id]);
+
+            if (!resume) {
+                throw new NotFoundException('이력서를 찾을 수 없습니다.');
+            }
+
+            if (resume.user_id !== userId) {
+                throw new ForbiddenException('이력서를 수정할 권한이 없습니다.');
+            }
+
+            // 이력서 업데이트
+            const updateSql = `
+        UPDATE resume 
+        SET title = ?, updated_at = NOW() 
+        WHERE resume_id = ?
+      `;
+
+            await this.databaseService.query(updateSql, [updateResumeDto.title, id]);
+
+            // 업데이트된 이력서 조회
+            const selectSql = `SELECT * FROM resume WHERE resume_id = ?`;
+            const updatedResume = await this.databaseService.queryOne<Resume>(selectSql, [id]);
+            if (!updatedResume) {
+                throw new NotFoundException('이력서를 찾을 수 없습니다.');
+            }
+
+            return updatedResume;
+        } catch (error) {
+            if (error instanceof NotFoundException || error instanceof ForbiddenException) {
+                throw error;
+            }
+            throw new BadRequestException('이력서 수정에 실패했습니다.');
+        }
+    }
+
+    async remove(id: number, userId: number): Promise<void> {
+        try {
+            // 이력서 소유권 확인
+            const checkSql = `SELECT user_id FROM resume WHERE resume_id = ?`;
+            const resume = await this.databaseService.queryOne<{ user_id: number }>(checkSql, [id]);
+
+            if (!resume) {
+                throw new NotFoundException('이력서를 찾을 수 없습니다.');
+            }
+
+            if (resume.user_id !== userId) {
+                throw new ForbiddenException('이력서를 삭제할 권한이 없습니다.');
+            }
+
+            // 트랜잭션으로 관련 데이터 모두 삭제
+            await this.databaseService.transaction(async (connection) => {
+                // 관련 테이블들 삭제 (외래키 제약조건으로 자동 삭제되지만 명시적으로)
+                await connection.execute('DELETE FROM resume_career WHERE resume_id = ?', [id]);
+                await connection.execute('DELETE FROM resume_skill WHERE resume_id = ?', [id]);
+                await connection.execute('DELETE FROM resume_education WHERE resume_id = ?', [id]);
+                await connection.execute('DELETE FROM resume_experience WHERE resume_id = ?', [id]);
+                await connection.execute('DELETE FROM resume_coverletter WHERE resume_id = ?', [
+                    id,
+                ]);
+                await connection.execute('DELETE FROM resume_portfolio WHERE resume_id = ?', [id]);
+
+                // 이력서 삭제
+                await connection.execute('DELETE FROM resume WHERE resume_id = ?', [id]);
+            });
+        } catch (error) {
+            if (error instanceof NotFoundException || error instanceof ForbiddenException) {
+                throw error;
+            }
+            throw new BadRequestException('이력서 삭제에 실패했습니다.');
+        }
+    }
+
+    private transformToListResponse(resume: any): ResumeListResponseDto {
+        // 가장 최근 경력 정보 가져오기
+        const companies = resume.companies ? resume.companies.split(',') : [];
+        const positions = resume.positions ? resume.positions.split(',') : [];
+
+        // 총 경력 계산
+        const totalExperience = this.calculateExperienceFromCompanies(companies);
+
+        // 스킬 목록
+        const skills = resume.skills ? resume.skills.split(',') : [];
+
+        return {
+            id: resume.resume_id,
+            title: resume.title,
+            position: positions[0] || '미정',
+            company: companies[0] || '미정',
+            createdAt: new Date(resume.created_at).toISOString().split('T')[0],
+            experience: totalExperience,
+            skills: skills,
+        };
+    }
+
+    private calculateExperienceFromCompanies(companies: string[]): string {
+        if (!companies || companies.length === 0) {
+            return '신입';
+        }
+
+        // 간단한 경력 계산 (회사 수 기반)
+        // 실제로는 더 정교한 계산이 필요
+        const companyCount = companies.length;
+        if (companyCount === 1) {
+            return '1-2년';
+        } else if (companyCount === 2) {
+            return '3-5년';
+        } else {
+            return `${companyCount * 2}년+`;
+        }
+    }
+}


### PR DESCRIPTION
- 이력서 생성, 조회, 수정 및 삭제 기능을 담당하는 api가 추가되었습니다.
- 조회 기능에 대해서는 정상 작동 확인되었습니다. (AI 인터뷰 시작 화면에서 사용자의 이력서 조회)
- 이력서 등록/수정/삭제 페이지 구현 시 나머지 기능을 사용할 수 있으나, 검증되지 않은 에러가 발생할 수 있습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 이력서 기능 추가: 생성, 사용자별 목록 조회, 상세 조회, 수정, 삭제 지원.
  - 입력 검증 강화: 이력서 제목 필수·문자열·최대 255자 제한.
  - API 응답 구조 제공: 목록(제목/회사/포지션/경력/스킬) 및 상세(경력·스킬·학력·경험·자소서·포트폴리오) 형태.
- 문서
  - 이력서 관련 엔드포인트와 DTO에 API 문서 메타데이터 추가로 Swagger 문서화 개선.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->