### PR TITLE
[feat] 멘토 본인의 mentor_idx 조회 API 추가

### DIFF
--- a/src/auth/session.guard.ts
+++ b/src/auth/session.guard.ts
@@ -39,8 +39,9 @@ export class SessionGuard implements CanActivate {
             (req.path as string).startsWith('/api/mentors/') ||
             // TODO: mentees 엔드포인트(신청 조회) 임시 공개. 인증 연동 후 제거할 것.
             (req.path as string).startsWith('/api/mentees/') ||
-            // TODO: mentoring-applications 임시 공개. 인증 연동 후 제거할 것.
-            (req.path as string).startsWith('/api/mentoring-applications/')
+            // mentoring-applications 중 my/mentor-idx는 인증 필요, 나머지만 공개
+            ((req.path as string).startsWith('/api/mentoring-applications/') &&
+                !(req.path as string).includes('/my/mentor-idx'))
         ) {
             // 비로그인 접근 시, 의존 로직을 위해 guest 사용자 idx를 0으로 설정
             if (!req.user_idx) {

--- a/src/modules/mentoring/dto/mentor.dto.ts
+++ b/src/modules/mentoring/dto/mentor.dto.ts
@@ -5,3 +5,7 @@ export class MentorDto {
     business_name: string; // e.g., 회사명
 }
 
+export class MyMentorIdxResponseDto {
+    mentor_idx: number | null;
+    is_mentor: boolean;
+}

--- a/src/modules/mentoring/mentoring-applications.controller.ts
+++ b/src/modules/mentoring/mentoring-applications.controller.ts
@@ -1,14 +1,28 @@
-import { Body, Controller, Get, Param, Patch, Query } from '@nestjs/common';
+import { Body, Controller, Get, Param, Patch, Query, Req } from '@nestjs/common';
 import { MentoringService } from './mentoring.service';
 import { MentoringApplicationsResponseDto } from './dto/mentoring-applications.dto';
 import {
     UpdateApplicationStatusDto,
     UpdateApplicationStatusResponseDto,
 } from './dto/application-update.dto';
+import { MyMentorIdxResponseDto } from './dto/mentor.dto';
 
 @Controller('mentoring-applications')
 export class MentoringApplicationsController {
     constructor(private readonly svc: MentoringService) {}
+
+    @Get('my/mentor-idx')
+    async getMyMentorIdx(@Req() req: any): Promise<MyMentorIdxResponseDto> {
+        const userIdx = req.user_idx as number;
+        console.log(
+            `🚀 [MentoringApplicationsController] getMyMentorIdx API 호출됨. userIdx: ${userIdx}`,
+        );
+
+        const result = await this.svc.getMyMentorIdx(userIdx);
+        console.log(`📤 [MentoringApplicationsController] 최종 응답:`, result);
+
+        return result;
+    }
 
     @Get(':user_idx')
     async getApplications(

--- a/src/modules/mentoring/mentoring.service.ts
+++ b/src/modules/mentoring/mentoring.service.ts
@@ -1051,4 +1051,30 @@ export class MentoringService {
             throw new BadRequestException('멘토링 상품 리스트를 조회하는 중 오류가 발생했습니다.');
         }
     }
+
+    async getMyMentorIdx(
+        userIdx: number,
+    ): Promise<{ mentor_idx: number | null; is_mentor: boolean }> {
+        try {
+            const mentorRow = await this.databaseService.queryOne<{ mentor_idx: number }>(
+                'SELECT mentor_idx FROM mentor_profiles WHERE user_idx = ? LIMIT 1',
+                [userIdx],
+            );
+
+            if (!mentorRow) {
+                return {
+                    mentor_idx: null,
+                    is_mentor: false,
+                };
+            }
+
+            return {
+                mentor_idx: mentorRow.mentor_idx,
+                is_mentor: true,
+            };
+        } catch (error) {
+            console.error('멘토 idx 조회 실패:', error);
+            throw new BadRequestException('멘토 정보를 조회하는 중 오류가 발생했습니다.');
+        }
+    }
 }


### PR DESCRIPTION
- GET /api/mentoring-applications/my/mentor-idx 엔드포인트 구현
- 멘토 여부(is_mentor)와 mentor_idx 반환

## 사용 방법
### API 호출
```
GET /api/mentoring-applications/my/mentor-idx
```
### 응답 예시
멘토인 경우:
```
{
    "mentor_idx": 123,
    "is_mentor": true
}
```
멘토가 아닌 경우:
```
{
    "mentor_idx": null,
    "is_mentor": false
}
```