### PR TITLE
[ feat ] AI 인터뷰 결과리포트 점수 산출 로직 변경, 1분 자기소개 대본 기능 추가

### DIFF
--- a/sql/interview.sql
+++ b/sql/interview.sql
@@ -30,6 +30,15 @@ CREATE TABLE IF NOT EXISTS visual_agg_question (
   confidence_max   DOUBLE NULL,
   smile_mean       DOUBLE NULL,
   smile_max        DOUBLE NULL,
+  eye_contact_mean DOUBLE NULL,
+  blink_mean       DOUBLE NULL,
+  gaze_stability   DOUBLE NULL,
+  attention_mean   DOUBLE NULL,
+  attention_max    DOUBLE NULL,
+  engagement_mean  DOUBLE NULL,
+  engagement_max   DOUBLE NULL,
+  nervousness_mean DOUBLE NULL,
+  nervousness_max  DOUBLE NULL,
   presence_good    INT NOT NULL DEFAULT 0,
   presence_average INT NOT NULL DEFAULT 0,
   presence_needs_improvement INT NOT NULL DEFAULT 0,
@@ -37,14 +46,10 @@ CREATE TABLE IF NOT EXISTS visual_agg_question (
   level_info       INT NOT NULL DEFAULT 0,
   level_warning    INT NOT NULL DEFAULT 0,
   level_critical   INT NOT NULL DEFAULT 0,
-  left_eye_x_mean  DOUBLE NULL,
-  left_eye_y_mean  DOUBLE NULL,
-  right_eye_x_mean DOUBLE NULL,
-  right_eye_y_mean DOUBLE NULL,
-  nose_x_mean      DOUBLE NULL,
-  nose_y_mean      DOUBLE NULL,
   started_at_ms    BIGINT NULL,
   ended_at_ms      BIGINT NULL,
+  normalized_score DOUBLE NULL COMMENT '캘리브레이션 적용된 정규화 점수',
+  calibration_applied TINYINT(1) NOT NULL DEFAULT 0 COMMENT '캘리브레이션 적용 여부',
   updated_at       TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   PRIMARY KEY (session_id, question_id),
   CONSTRAINT fk_vqa_q FOREIGN KEY (session_id, question_id) REFERENCES questions(session_id, question_id) ON DELETE CASCADE
@@ -58,6 +63,15 @@ CREATE TABLE IF NOT EXISTS visual_agg_session (
   confidence_max   DOUBLE NULL,
   smile_mean       DOUBLE NULL,
   smile_max        DOUBLE NULL,
+  eye_contact_mean DOUBLE NULL,
+  blink_mean       DOUBLE NULL,
+  gaze_stability   DOUBLE NULL,
+  attention_mean   DOUBLE NULL,
+  attention_max    DOUBLE NULL,
+  engagement_mean  DOUBLE NULL,
+  engagement_max   DOUBLE NULL,
+  nervousness_mean DOUBLE NULL,
+  nervousness_max  DOUBLE NULL,
   presence_good    INT NOT NULL DEFAULT 0,
   presence_average INT NOT NULL DEFAULT 0,
   presence_needs_improvement INT NOT NULL DEFAULT 0,
@@ -85,6 +99,8 @@ CREATE TABLE IF NOT EXISTS audio_metrics_question (
   shimmer_like      DOUBLE NULL,
   silence_ratio     DOUBLE NULL,
   sr                INT NULL,
+  normalized_score DOUBLE NULL COMMENT '캘리브레이션 적용된 정규화 점수',
+  calibration_applied TINYINT(1) NOT NULL DEFAULT 0 COMMENT '캘리브레이션 적용 여부',
   updated_at        TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   PRIMARY KEY (session_id, question_id),
   CONSTRAINT fk_amq_q FOREIGN KEY (session_id, question_id) REFERENCES questions(session_id, question_id) ON DELETE CASCADE
@@ -155,14 +171,7 @@ CREATE TABLE IF NOT EXISTS session_calibrations (
   INDEX idx_session_calibration_created (created_at)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
--- 기존 테이블에 캘리브레이션 컬럼 추가
-ALTER TABLE audio_metrics_question 
-ADD COLUMN normalized_score DOUBLE NULL COMMENT '캘리브레이션 적용된 정규화 점수' AFTER sr,
-ADD COLUMN calibration_applied TINYINT(1) NOT NULL DEFAULT 0 COMMENT '캘리브레이션 적용 여부' AFTER normalized_score;
-
-ALTER TABLE visual_agg_question
-ADD COLUMN normalized_score DOUBLE NULL COMMENT '캘리브레이션 적용된 정규화 점수' AFTER ended_at_ms,
-ADD COLUMN calibration_applied TINYINT(1) NOT NULL DEFAULT 0 COMMENT '캘리브레이션 적용 여부' AFTER normalized_score;
+-- 기존 테이블 증설용 ALTER 구문은 초기 스키마에 반영되어 제거됨
 
 -- Resume file chunks with optional embeddings for MMR/RAG
 CREATE TABLE IF NOT EXISTS resume_file_chunks (

--- a/src/modules/calibration/calibration.service.ts
+++ b/src/modules/calibration/calibration.service.ts
@@ -328,12 +328,6 @@ export class CalibrationService {
             level_info: 8,
             level_warning: 2,
             level_critical: 0,
-            left_eye_x_mean: 0.3,
-            left_eye_y_mean: 0.4,
-            right_eye_x_mean: 0.7,
-            right_eye_y_mean: 0.4,
-            nose_x_mean: 0.5,
-            nose_y_mean: 0.6,
             started_at_ms: 0,
             ended_at_ms: 15000,
         } as VisualAggregateDto;

--- a/src/modules/metrics/dto/visual-aggregate.dto.ts
+++ b/src/modules/metrics/dto/visual-aggregate.dto.ts
@@ -8,6 +8,18 @@ export class VisualAggregateDto {
     @IsOptional() @IsNumber() smile_mean?: number | null;
     @IsOptional() @IsNumber() smile_max?: number | null;
 
+    // 추가 지표(평균/최대 등) - 프론트 RealMediaPipeAnalyzer와 정렬
+    @IsOptional() @IsNumber() eye_contact_mean?: number | null; // 0~1
+    @IsOptional() @IsNumber() blink_mean?: number | null; // 0~1
+    @IsOptional() @IsNumber() gaze_stability?: number | null; // 0~1
+
+    @IsOptional() @IsNumber() attention_mean?: number | null; // 0~1
+    @IsOptional() @IsNumber() attention_max?: number | null; // 0~1
+    @IsOptional() @IsNumber() engagement_mean?: number | null; // 0~1
+    @IsOptional() @IsNumber() engagement_max?: number | null; // 0~1
+    @IsOptional() @IsNumber() nervousness_mean?: number | null; // 0~1
+    @IsOptional() @IsNumber() nervousness_max?: number | null; // 0~1
+
     @IsInt() presence_good!: number;
     @IsInt() presence_average!: number;
     @IsInt() presence_needs_improvement!: number;
@@ -16,13 +28,6 @@ export class VisualAggregateDto {
     @IsInt() level_info!: number;
     @IsInt() level_warning!: number;
     @IsInt() level_critical!: number;
-
-    @IsOptional() @IsNumber() left_eye_x_mean?: number | null;
-    @IsOptional() @IsNumber() left_eye_y_mean?: number | null;
-    @IsOptional() @IsNumber() right_eye_x_mean?: number | null;
-    @IsOptional() @IsNumber() right_eye_y_mean?: number | null;
-    @IsOptional() @IsNumber() nose_x_mean?: number | null;
-    @IsOptional() @IsNumber() nose_y_mean?: number | null;
 
     @IsOptional() @IsNumber() started_at_ms?: number | null;
     @IsOptional() @IsNumber() ended_at_ms?: number | null;

--- a/src/modules/metrics/metrics.types.ts
+++ b/src/modules/metrics/metrics.types.ts
@@ -25,13 +25,6 @@ export type QuestionVisualAggregate = {
     // level 분포
     level_dist: Record<'ok' | 'info' | 'warning' | 'critical', number>;
 
-    // 랜드마크 평균(존재하는 것만)
-    landmarks_mean?: {
-        leftEye?: { x: number; y: number };
-        rightEye?: { x: number; y: number };
-        nose?: { x: number; y: number };
-    };
-
     // 샘플 시간 범위(선택)
     startedAt?: number;
     endedAt?: number;
@@ -39,7 +32,5 @@ export type QuestionVisualAggregate = {
 
 export type SessionVisualAggregate = {
     perQuestion: Record<string, QuestionVisualAggregate>;
-    overall: Omit<QuestionVisualAggregate, 'landmarks_mean'> & {
-        // 전체는 랜드마크 평균은 생략(질문별에만 보관), 필요 시 가중 평균으로 계산 가능
-    };
+    overall: QuestionVisualAggregate;
 };

--- a/src/modules/report/dto/analyze-report.dto.ts
+++ b/src/modules/report/dto/analyze-report.dto.ts
@@ -1,4 +1,4 @@
-import { IsArray, IsString, ValidateNested } from 'class-validator';
+import { IsArray, IsNumber, IsOptional, IsString, ValidateNested } from 'class-validator';
 import { Type } from 'class-transformer';
 
 export class QADto {
@@ -14,4 +14,13 @@ export class AnalyzeReportDto {
     @ValidateNested({ each: true })
     @Type(() => QADto)
     qa!: QADto[];
+
+    // LLM 기반 내용/맥락 점수(0~100), 선택 전달
+    @IsOptional()
+    @IsNumber()
+    llmContentScore?: number;
+
+    @IsOptional()
+    @IsNumber()
+    llmContextScore?: number;
 }

--- a/src/modules/report/report.controller.ts
+++ b/src/modules/report/report.controller.ts
@@ -8,7 +8,7 @@ export class ReportController {
 
     @Post(':sessionId/analyze')
     async analyze(@Param('sessionId') sessionId: string, @Body() dto: AnalyzeReportDto) {
-        const data = await this.svc.computeAndMaybeSave(sessionId, dto.qa);
+        const data = await this.svc.computeAndMaybeSave(sessionId, dto);
         return { success: true, data };
     }
 
@@ -16,8 +16,8 @@ export class ReportController {
     async get(@Param('sessionId') sessionId: string) {
         const saved = await this.svc.getSavedReport(sessionId);
         if (saved) return { success: true, data: saved };
-        // if not saved, try to compute on-the-fly with empty QA
-        const data = await this.svc.computeOnTheFly(sessionId, []);
+        // if not saved, try to compute on-the-fly
+        const data = await this.svc.computeOnTheFly(sessionId, { qa: [] } as any);
         return { success: true, data };
     }
 

--- a/src/modules/report/report.module.ts
+++ b/src/modules/report/report.module.ts
@@ -5,9 +5,10 @@ import { MetricsModule } from '../metrics/metrics.module';
 import { AudioMetricsService } from '../audio-metrics/audio-metrics.service';
 import { DatabaseModule } from '../../database/database.module';
 import { CalibrationModule } from '../calibration/calibration.module';
+import { OpenAIModule } from '../openai/openai.module';
 
 @Module({
-    imports: [MetricsModule, DatabaseModule, CalibrationModule],
+    imports: [MetricsModule, DatabaseModule, CalibrationModule, OpenAIModule],
     controllers: [ReportController],
     providers: [ReportService, AudioMetricsService],
     exports: [ReportService],


### PR DESCRIPTION
- 결과리포트의 점수 산출 방식이 완전히 변경되었습니다.
- 이력서 요약 내용을 바탕으로 1분 자기소개 대본을 생성하는 기능이 추가되었습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 눈맞춤, 깜빡임, 시선 안정성, 주의/주의최대, 몰입/몰입최대, 긴장도/긴장도최대 등 시각 지표 추가.
  - 문항·세션별 지표에 교정(캘리브레이션) 적용 여부와 정규화 점수 지원.
  - 리포트가 OpenAI 기반으로 업그레이드되어 content30/context30/expression40 점수, 오디오/비주얼 요약, 텍스트 분석 요약, 근거 링크 제공.
  - 이력서 요약을 바탕으로 1분 자기소개 스크립트 생성.

- 리팩터링
  - 좌표 기반 얼굴 랜드마크 지표 제거로 지표 체계 단순화.
  - 리포트 입력을 DTO로 통합하고 결과 페이로드 구조를 개편.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->