### PR TITLE
[fix] HTTPS 환경에서 로그아웃 시 쿠키 삭제 실패 문제 해결

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -152,7 +152,25 @@ export class AuthController {
     // 로그아웃 엔드포인트, 세션 쿠키 삭제
     @Get('logout')
     logout(@Res() res: Response) {
-        res.clearCookie('session', { path: '/' });
+        const isProd = this.configService.isProduction;
+
+        // 로그인 시와 동일한 쿠키 옵션으로 삭제
+        const cookieOptions = {
+            path: '/',
+            // 프로덕션 환경 (HTTPS, 크로스 도메인)
+            ...(isProd && {
+                secure: true,
+                sameSite: 'none' as const,
+                domain: '.good-job.shop',
+            }),
+            // 로컬 환경 (HTTP, 같은 도메인)
+            ...(!isProd && {
+                secure: false,
+                sameSite: 'lax' as const,
+            }),
+        };
+
+        res.clearCookie('session', cookieOptions);
         return res.status(204).send();
     }
 


### PR DESCRIPTION
- 로그아웃 엔드포인트에서 쿠키 삭제 시 로그인과 동일한 옵션 사용
- HTTPS 환경에서 secure, sameSite, domain 옵션이 누락되어 쿠키 삭제가 실패하던 문제 수정
- 환경별 쿠키 옵션을 로그인과 로그아웃에서 일관성 있게 적용