### PR TITLE
캔버스 데이터 자동 저장

### DIFF
--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -164,9 +164,12 @@ CREATE TABLE canvas (
     application_id INT NOT NULL,               -- 연결된 멘토링 신청 ID
     name VARCHAR(255) NULL,                    -- 캔버스 이름
     created_by INT NOT NULL,                   -- 캔버스를 만든 유저
+    json_data JSON NULL COMMENT 'Fabric.js 오브젝트 직렬화 상태 저장',
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    CONSTRAINT fk_canvas_user FOREIGN KEY (created_by) REFERENCES users(idx) ON DELETE CASCADE,
-    CONSTRAINT fk_canvas_application FOREIGN KEY (application_id) REFERENCES mentoring_applications(application_id) ON DELETE CASCADE,
+    CONSTRAINT fk_canvas_user FOREIGN KEY (created_by) 
+        REFERENCES users(idx) ON DELETE CASCADE,
+    CONSTRAINT fk_canvas_application FOREIGN KEY (application_id) 
+        REFERENCES mentoring_applications(application_id) ON DELETE CASCADE,
     UNIQUE KEY uq_canvas_application (application_id)  -- 1:1 관계 보장
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -160,12 +160,16 @@ CREATE TABLE `conversation_read_status` (
 DROP TABLE IF EXISTS `canvas`;
 -- 캔버스 기본 정보
 CREATE TABLE canvas (
-    id CHAR(36) NOT NULL PRIMARY KEY,   -- UUID (문자열)
-    name VARCHAR(255) NULL,             -- 캔버스 이름
-    created_by INT NOT NULL,            -- 캔버스를 만든 유저
+    id CHAR(36) NOT NULL PRIMARY KEY,          -- UUID (문자열)
+    application_id INT NOT NULL,               -- 연결된 멘토링 신청 ID
+    name VARCHAR(255) NULL,                    -- 캔버스 이름
+    created_by INT NOT NULL,                   -- 캔버스를 만든 유저
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    FOREIGN KEY (created_by) REFERENCES users(idx) ON DELETE CASCADE
-);
+    CONSTRAINT fk_canvas_user FOREIGN KEY (created_by) REFERENCES users(idx) ON DELETE CASCADE,
+    CONSTRAINT fk_canvas_application FOREIGN KEY (application_id) REFERENCES mentoring_applications(application_id) ON DELETE CASCADE,
+    UNIQUE KEY uq_canvas_application (application_id)  -- 1:1 관계 보장
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
 
 DROP TABLE IF EXISTS `canvas_participant`;
 -- 캔버스 참여자 정보

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -164,7 +164,7 @@ CREATE TABLE canvas (
     application_id INT NOT NULL,               -- 연결된 멘토링 신청 ID
     name VARCHAR(255) NULL,                    -- 캔버스 이름
     created_by INT NOT NULL,                   -- 캔버스를 만든 유저
-    json_data JSON NULL COMMENT 'Fabric.js 오브젝트 직렬화 상태 저장',
+    json_data LONGTEXT NULL COMMENT 'Fabric.js 오브젝트 직렬화 상태 저장',
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     CONSTRAINT fk_canvas_user FOREIGN KEY (created_by) 
         REFERENCES users(idx) ON DELETE CASCADE,

--- a/src/modules/coaching-resume/canvas.controller.ts
+++ b/src/modules/coaching-resume/canvas.controller.ts
@@ -1,14 +1,14 @@
-import { Body, Controller, Post, Req } from '@nestjs/common';
+import { Body, Controller, Get, Param, Post, Req } from '@nestjs/common';
 import { CanvasService } from './canvas.service';
 import { CreateCanvasDto } from './dto/create-canvas.dto';
 import { UploadCanvasDto } from './dto/upload-canvas.dto';
 
-@Controller('coaching-resume/canvas')
+@Controller('coaching-resume')
 export class CanvasController {
     constructor(private readonly canvasService: CanvasService) {}
 
     // @UseGuards(AuthGuard)
-    @Post()
+    @Post('canvas')
     async createCanvas(@Body() dto: CreateCanvasDto, @Req() req: any) {
         // const userId = req.user.idx; // JWT 가드에서 넣어준 유저 ID
         const userId = 1;
@@ -16,10 +16,17 @@ export class CanvasController {
     }
 
     // 캔버스에서 전송된 dataURL 이미지를 S3에 업로드
-    @Post('upload')
+    @Post('canvas/upload')
     async uploadCanvas(@Body() body: UploadCanvasDto) {
         const { dataUrl, fileName } = body;
         const result = await this.canvasService.uploadCanvasImage(dataUrl, fileName);
         return { url: result.url };
+    }
+
+    // 캔버스 상세 조회 (멘토/멘티 정보 포함)
+    @Get(':canvasId')
+    async getCanvasById(@Param('canvasId') canvasId: string, @Req() req: any) {
+        const requesterId = req?.user?.idx ?? req?.user_idx;
+        return this.canvasService.getCanvasDetail(canvasId, requesterId);
     }
 }

--- a/src/modules/collab/collab.module.ts
+++ b/src/modules/collab/collab.module.ts
@@ -1,7 +1,9 @@
 import { Module } from '@nestjs/common';
+import { DatabaseModule } from '../../database/database.module';
 import { CollabGateway } from './collab.gateway';
 
 @Module({
+    imports: [DatabaseModule],
     providers: [CollabGateway],
 })
 export class CollabModule {}

--- a/src/modules/mentoring/dto/mentoring-applications.dto.ts
+++ b/src/modules/mentoring/dto/mentoring-applications.dto.ts
@@ -14,7 +14,7 @@ export class MentoringApplicationItemDto {
     application_id: number;
     product_idx: number;
     product_title: string;
-    booked_date: string; // YYYY-MM-DD
+    booked_date: string | null; // YYYY-MM-DD or null
     application_status: 'pending' | 'approved' | 'rejected' | 'cancelled' | 'completed';
     mentee: MenteeSummaryDto;
     mentor: MentorSummaryDto;
@@ -31,4 +31,3 @@ export class MentoringApplicationsResponseDto {
     applications: MentoringApplicationItemDto[];
     page_info: MentoringApplicationsPageInfoDto;
 }
-

--- a/src/modules/mentoring/mentoring-applications.controller.ts
+++ b/src/modules/mentoring/mentoring-applications.controller.ts
@@ -35,6 +35,17 @@ export class MentoringApplicationsController {
         return await this.svc.getMentoringApplications(Number(userIdx), p, l);
     }
 
+    @Get('my/:user_idx')
+    async getMyApplications(
+        @Param('user_idx') userIdx: string,
+        @Query('page') page?: string,
+        @Query('limit') limit?: string,
+    ): Promise<MentoringApplicationsResponseDto> {
+        const p = page ? Number(page) : 1;
+        const l = limit ? Number(limit) : 10;
+        return await this.svc.getMyMentoringApplications(Number(userIdx), p, l);
+    }
+
     @Patch(':application_id')
     async updateStatus(
         @Param('application_id') applicationId: string,

--- a/src/modules/mentoring/mentoring.service.ts
+++ b/src/modules/mentoring/mentoring.service.ts
@@ -896,7 +896,7 @@ export class MentoringService {
         };
     }
 
-    async getMentoringApplications(
+    async getMyMentoringApplications(
         userIdx: number,
         page = 1,
         limit = 10,
@@ -971,6 +971,92 @@ export class MentoringService {
                 limit,
                 total,
                 has_next: offset + limit < total,
+            },
+        };
+    }
+
+    async getMentoringApplications(
+        userIdx: number,
+        page = 1,
+        limit = 10,
+    ): Promise<MentoringApplicationsResponseDto> {
+        const mentorRow = await this.databaseService.queryOne<{ mentor_idx: number }>(
+            'SELECT mentor_idx FROM mentor_profiles WHERE user_idx = ? LIMIT 1',
+            [userIdx],
+        );
+
+        if (!mentorRow) {
+            return {
+                applications: [],
+                page_info: { page, limit, total: 0, has_next: false },
+            } as MentoringApplicationsResponseDto;
+        }
+
+        const mentorIdx = mentorRow.mentor_idx;
+
+        const countSql = `
+            SELECT COUNT(*) AS total
+              FROM mentoring_applications a
+              JOIN mentoring_products p ON a.product_idx = p.product_idx
+             WHERE p.mentor_idx = ?
+        `;
+        const countRow = await this.databaseService.queryOne<{ total: number }>(countSql, [
+            mentorIdx,
+        ]);
+        const total = Number(countRow?.total ?? 0);
+
+        const offset = (Number(page) - 1) * Number(limit);
+        const listSql = `
+            SELECT 
+                a.application_id,
+                a.product_idx,
+                p.title AS product_title,
+                a.booked_date,
+                a.application_status,
+                mpu.idx AS mentee_idx,
+                mpu.name AS mentee_name,
+                mpu.profile_img AS mentee_profile_img,
+                mp.mentor_idx,
+                mp.business_name,
+                jc.name AS mentor_job_category
+            FROM mentoring_applications a
+            JOIN mentoring_products p ON a.product_idx = p.product_idx
+            JOIN mentor_profiles mp ON p.mentor_idx = mp.mentor_idx
+            JOIN job_category jc ON mp.preferred_field_id = jc.id
+            JOIN users mpu ON a.mentee_idx = mpu.idx
+            WHERE p.mentor_idx = ?
+            ORDER BY a.created_at DESC
+            LIMIT ? OFFSET ?
+        `;
+        const rows = await this.databaseService.query<any>(listSql, [
+            mentorIdx,
+            Number(limit),
+            offset,
+        ]);
+
+        return {
+            applications: rows.map((r: any) => ({
+                application_id: r.application_id,
+                product_idx: r.product_idx,
+                product_title: r.product_title,
+                booked_date: new Date(r.booked_date).toISOString().slice(0, 10),
+                application_status: r.application_status,
+                mentee: {
+                    user_idx: r.mentee_idx,
+                    name: r.mentee_name,
+                    profile_img: r.mentee_profile_img ?? '',
+                },
+                mentor: {
+                    mentor_idx: r.mentor_idx,
+                    business_name: r.business_name,
+                    job_category: r.mentor_job_category,
+                },
+            })),
+            page_info: {
+                page: Number(page),
+                limit: Number(limit),
+                total,
+                has_next: offset + Number(limit) < total,
             },
         };
     }


### PR DESCRIPTION
- map을 활용해서 rooms 중 그림이 그려진 rooms만 반복하며 서버에 저장함
- 다시 접근할 경우 db에서 바로 반환하는게 아닌 map에서 먼저 찾고 db 조회를 함

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 캔버스 상세 조회 API 추가: 참여자(멘토/멘티), 일정, 권한 정보 포함.
  - 실시간 캔버스 협업 상태가 서버에 자동 저장(주기적)되고 재접속 시 복원됩니다.
  - 내 멘토링 신청 목록 조회 API 추가: 페이지네이션 지원.
- 변경 사항
  - 코칭 이력서(캔버스) 관련 일부 엔드포인트 경로가 조정되었습니다. 기존 통합 지점 사용 시 최신 경로로 업데이트하세요.
- 기타
  - 예약 날짜 필드가 null을 허용하도록 확장되어 미배정 상태를 명확히 표현합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->