### PR TITLE
[ feat ] 채용공고 url 파싱 및 관련 질문 생성 기능 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,9 @@
         "db:init": "node scripts/setup-database-universal.js",
         "db:init:reset": "node scripts/setup-database-universal.js --reset",
         "db:init:with-data": "node scripts/setup-database-universal.js --with-data",
-        "db:init:with-data:reset": "node scripts/setup-database-universal.js --reset --with-data"
+        "db:init:with-data:reset": "node scripts/setup-database-universal.js --reset --with-data",
+        "db:cleanup:calibration": "node scripts/cleanup-calibration-json.js",
+        "db:cleanup:calibration:dry": "node scripts/cleanup-calibration-json.js --dry-run"
     },
     "dependencies": {
         "@aws-sdk/client-s3": "^3.879.0",
@@ -33,6 +35,7 @@
         "@google-cloud/speech": "^7.2.0",
         "@google-cloud/storage": "^7.17.0",
         "@google-cloud/text-to-speech": "^6.3.0",
+        "@google-cloud/vision": "^5.3.3",
         "@nestjs/axios": "^4.0.1",
         "@nestjs/common": "^11.0.1",
         "@nestjs/config": "^4.0.2",
@@ -65,6 +68,7 @@
         "passport": "^0.7.0",
         "passport-jwt": "^4.0.1",
         "pdfjs-dist": "^5.4.149",
+        "playwright": "^1.55.0",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1",
         "socket.io": "^4.8.1",

--- a/src/modules/interview/interview.controller.ts
+++ b/src/modules/interview/interview.controller.ts
@@ -9,13 +9,21 @@ import {
     type CreateFollowupsParams,
     type AnalysisResult,
 } from './interview.service';
+import { JobExtractService, type ExtractResult } from './job-extract.service';
 import { DatabaseService } from '@/database/database.service';
 
 // ===== 요청 바디 스키마 & 타입 =====
-const CreateQuestionBodySchema = z.union([
-    z.object({ resumeSummary: z.string().min(10) }),
-    z.object({ resumeFileId: z.string().min(1) }),
-]);
+const CreateQuestionBodySchema = z
+    .union([
+        z.object({ resumeSummary: z.string().min(10) }),
+        z.object({ resumeFileId: z.string().min(1) }),
+    ])
+    .and(
+        z.object({
+            sessionId: z.string().optional(),
+            jobPostUrl: z.string().url().optional(),
+        }),
+    );
 
 const CreateFollowupsBodySchema = z.object({
     originalQuestion: z.object({
@@ -23,6 +31,7 @@ const CreateFollowupsBodySchema = z.object({
         text: z.string().min(5),
     }),
     answer: z.string().min(5),
+    sessionId: z.string().optional(),
 });
 
 const AnalyzeAnswerBodySchema = z.object({
@@ -38,6 +47,7 @@ export class AiController {
         private readonly ai: AiService,
         private readonly resumeFiles: ResumeFileService,
         private readonly db: DatabaseService,
+        private readonly jobExtract: JobExtractService,
     ) {}
 
     // POST /api/ai/question
@@ -53,16 +63,60 @@ export class AiController {
         }
         const userId = Number((req as any).user_idx ?? (req as any).user?.idx);
         if (!userId) throw new BadRequestException('unauthorized');
+        const anyData = parsed.data as any;
+        const sessionId: string | undefined = anyData.sessionId;
+        const jobPostUrl: string | undefined = anyData.jobPostUrl;
+
         if ('resumeFileId' in parsed.data) {
             this.logger.log(`createQuestion: resumeFileId=${parsed.data.resumeFileId}`);
             const summary = await this.resumeFiles.getSummaryById(parsed.data.resumeFileId, userId);
             if (!summary || summary.length < 10) {
                 throw new BadRequestException('요약이 비어있습니다. 먼저 요약을 등록하세요.');
             }
-            return this.ai.createQuestion(summary);
+            return this.ai.createQuestionWithJobPost(summary, { sessionId, jobPostUrl });
         }
-        this.logger.log(`createQuestion: resumeSummaryLen=${parsed.data.resumeSummary.length}`);
-        return this.ai.createQuestion(parsed.data.resumeSummary);
+        this.logger.log(
+            `createQuestion: resumeSummaryLen=${parsed.data.resumeSummary.length}, jobPostUrl=${jobPostUrl ? 'Y' : 'N'}`,
+        );
+        return this.ai.createQuestionWithJobPost(parsed.data.resumeSummary, {
+            sessionId,
+            jobPostUrl,
+        });
+    }
+
+    // POST /api/ai/job-extract (프런트 사전 검증/프리뷰용)
+    @Post('job-extract')
+    async extractJob(@Body() body: unknown): Promise<ExtractResult & { summary?: string }> {
+        this.logger.log(
+            `POST /ai/job-extract bodyKeys=${Object.keys((body as any) || {}).join(',')}`,
+        );
+        const schema = z.object({ url: z.string().url(), sessionId: z.string().optional() });
+        const parsed = schema.safeParse(body);
+        if (!parsed.success) {
+            this.logger.warn(`job-extract 스키마 오류: ${JSON.stringify(parsed.error.flatten())}`);
+            throw new BadRequestException(parsed.error.flatten());
+        }
+        const { url, sessionId } = parsed.data as { url: string; sessionId?: string };
+        const r = await this.jobExtract.extract(url);
+        if (!r.ok) return r;
+        // LLM 요약을 추가로 생성하여 프리뷰 품질 개선
+        let summary: string | undefined;
+        try {
+            summary = await this.jobExtract.summarizeJobPost(r.content);
+        } catch {
+            summary = undefined;
+        }
+        try {
+            if (sessionId) {
+                this.ai.setJobContext(sessionId, {
+                    url,
+                    title: r.ok ? r.title : undefined,
+                    company: r.ok ? r.company : undefined,
+                    summary: summary,
+                });
+            }
+        } catch {}
+        return { ...r, summary };
     }
 
     // POST /api/ai/followups
@@ -79,8 +133,9 @@ export class AiController {
             throw new BadRequestException(parsed.error.flatten());
         }
         // 스키마로 보장된 타입을 서비스 입력 DTO로 그대로 사용
-        const params: CreateFollowupsParams = parsed.data;
-        return this.ai.createFollowups(params);
+        const params: CreateFollowupsParams = parsed.data as any;
+        const sessionId: string | undefined = (parsed.data as any).sessionId;
+        return this.ai.createFollowups(params, { sessionId });
     }
 
     /**

--- a/src/modules/interview/interview.module.ts
+++ b/src/modules/interview/interview.module.ts
@@ -1,12 +1,13 @@
 import { Module } from '@nestjs/common';
 import { AiController } from './interview.controller';
 import { AiService } from './interview.service';
+import { JobExtractService } from './job-extract.service';
 import { ResumeFileModule } from '@/modules/resume-file/resume-file.module';
 import { DatabaseService } from '@/database/database.service';
 
 @Module({
     imports: [ResumeFileModule],
     controllers: [AiController],
-    providers: [AiService, DatabaseService],
+    providers: [AiService, DatabaseService, JobExtractService],
 })
 export class AiModule {} // ← 반드시 'export class AiModule' 여야 합니다.

--- a/src/modules/interview/job-extract.service.ts
+++ b/src/modules/interview/job-extract.service.ts
@@ -1,0 +1,462 @@
+// src/modules/interview/job-extract.service.ts
+import { Injectable, Logger } from '@nestjs/common';
+import OpenAI from 'openai';
+import { AppConfigService } from '@/config/config.service';
+import { ImageAnnotatorClient } from '@google-cloud/vision';
+
+export type ExtractResult =
+    | {
+          ok: true;
+          url: string;
+          source: 'html' | 'ocr' | 'mixed';
+          title?: string;
+          company?: string;
+          content: string; // consolidated text
+          imagesTried: string[];
+          meta?: Record<string, string>;
+      }
+    | {
+          ok: false;
+          url: string;
+          error?: string;
+      };
+
+@Injectable()
+export class JobExtractService {
+    private readonly logger = new Logger(JobExtractService.name);
+    private readonly vision: ImageAnnotatorClient;
+    private readonly openai: OpenAI;
+
+    constructor(private readonly config: AppConfigService) {
+        if (!process.env.GOOGLE_APPLICATION_CREDENTIALS) {
+            this.logger.warn(
+                'GOOGLE_APPLICATION_CREDENTIALS 환경변수가 없습니다. Vision 사용 불가.',
+            );
+        }
+        // 인증 정보는 GOOGLE_APPLICATION_CREDENTIALS를 통해 자동 로드
+        this.vision = new ImageAnnotatorClient();
+        this.openai = new OpenAI({ apiKey: this.config.openai.apiKey });
+    }
+
+    // Public API
+    async extract(urlStr: string): Promise<ExtractResult> {
+        try {
+            const safe = this.validateUrl(urlStr);
+            if (!safe.ok) return { ok: false, url: urlStr, error: safe.error };
+
+            const t0 = Date.now();
+            let html = '';
+            let finalUrl: string | undefined = undefined;
+            try {
+                const r = await this.fetchHtml(urlStr);
+                html = r.html;
+                finalUrl = r.finalUrl;
+            } catch (e: any) {
+                const msg = String(e?.message || e || 'unknown');
+                if (/HTTP\s+(403|406|503)/.test(msg)) {
+                    this.logger.warn(
+                        `코드=fetch_blocked status=${msg.match(/HTTP\s+\d+/)?.[0] || 'unknown'} url=${urlStr}`,
+                    );
+                    try {
+                        const r2 = await this.fetchHtmlDynamic(urlStr);
+                        html = r2.html;
+                        finalUrl = r2.finalUrl;
+                        this.logger.log('코드=dynamic_fallback_ok');
+                    } catch (e2: any) {
+                        this.logger.error(
+                            `코드=dynamic_fallback_fail reason=${e2?.code || e2?.message || e2}`,
+                        );
+                        throw e; // 원 오류 전달
+                    }
+                } else {
+                    this.logger.error(`코드=fetch_error reason=${msg}`);
+                    throw e;
+                }
+            }
+            const baseUrl = finalUrl || urlStr;
+            const meta = this.extractMeta(html);
+            const textFromHtml = this.extractMainText(html);
+            const title = meta['og:title'] || meta.title || '';
+            const company = this.guessCompany(meta, textFromHtml);
+
+            let images: string[] = [];
+            let ocrText = '';
+
+            if (this.isTextInsufficient(textFromHtml)) {
+                images = this.extractImageUrls(html, baseUrl).slice(0, 5);
+                ocrText = await this.ocrImages(images);
+            }
+
+            const content = this.mergeContents(textFromHtml, ocrText);
+            const source: 'html' | 'ocr' | 'mixed' =
+                textFromHtml && ocrText ? 'mixed' : textFromHtml ? 'html' : 'ocr';
+
+            this.logger.log(
+                `job-extract 완료: url=${urlStr}, source=${source}, len=${content.length}, durMs=${Date.now() - t0}`,
+            );
+
+            if (!content || content.trim().length < 30) {
+                return { ok: false, url: urlStr, error: '본문 추출 실패(내용 부족)' };
+            }
+
+            return {
+                ok: true,
+                url: urlStr,
+                source,
+                title: title || undefined,
+                company: company || undefined,
+                content,
+                imagesTried: images,
+                meta,
+            };
+        } catch (e: any) {
+            this.logger.error(`job-extract 실패: ${e?.message}`);
+            return { ok: false, url: urlStr, error: e?.message || 'unknown error' };
+        }
+    }
+
+    // Playwright를 사용한 동적 렌더링 추출 (선택적)
+    private async fetchHtmlDynamic(urlStr: string): Promise<{ html: string; finalUrl?: string }> {
+        // 동적 import로 의존성 여부를 확인
+        let playwright: any;
+        try {
+            playwright = await import('playwright');
+        } catch (e: any) {
+            const msg = `playwright 모듈 없음`;
+            (e as any).code = 'dynamic_missing_dep';
+            this.logger.warn(`코드=dynamic_missing_dep url=${urlStr}`);
+            throw e;
+        }
+
+        const browser = await playwright.chromium.launch({
+            headless: true,
+            args: ['--no-sandbox', '--disable-dev-shm-usage'],
+        });
+        const ctx = await browser.newContext({
+            userAgent:
+                'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36',
+            viewport: { width: 1366, height: 900 },
+            locale: 'ko-KR',
+        });
+        const page = await ctx.newPage();
+        try {
+            page.setDefaultNavigationTimeout(15000);
+            await page.route('**/*', (route) => {
+                const req = route.request();
+                const resourceType = req.resourceType();
+                // 이미지/폰트/미디어는 차단하여 속도 향상
+                if (['image', 'font', 'media'].includes(resourceType)) {
+                    return route.abort();
+                }
+                return route.continue();
+            });
+            await page.goto(urlStr, { waitUntil: 'domcontentloaded' });
+            // JS 렌더링 대기(최대 2.5초)
+            try {
+                await page.waitForLoadState('networkidle', { timeout: 2500 });
+            } catch {}
+            const html = await page.evaluate(() => document.documentElement.outerHTML);
+            const finalUrl = page.url();
+            return { html, finalUrl };
+        } catch (e: any) {
+            (e as any).code = (e as any).code || 'dynamic_navigation_error';
+            this.logger.error(`코드=${(e as any).code} url=${urlStr} reason=${e?.message}`);
+            throw e;
+        } finally {
+            await ctx.close().catch(() => {});
+            await browser.close().catch(() => {});
+        }
+    }
+
+    // LLM 기반 채용공고 요약(한국어, 구조화)
+    async summarizeJobPost(text: string, maxChars = 1200): Promise<string> {
+        const t0 = Date.now();
+        const raw = (text || '').toString();
+        if (!raw.trim()) return '';
+        const system = '너는 채용공고를 요약하는 도우미다. 반드시 한국어로 간결히 핵심만 정리하라.';
+        const user =
+            `다음 채용공고를 간단 명료하게 요약해라. 형식:\n` +
+            `- 직무명:\n- 회사:\n- 주요업무: (2-4줄)\n- 필수요건: (불릿 3-6개)\n- 우대사항: (불릿 2-5개, 없으면 생략)\n- 핵심키워드: (콤마 구분 6-12개)\n문서:\n${raw.slice(0, 8000)}`;
+
+        try {
+            const r = await this.openai.chat.completions.create({
+                model: 'gpt-4o-mini',
+                temperature: 0.2,
+                messages: [
+                    { role: 'system', content: system },
+                    { role: 'user', content: user },
+                ],
+            });
+            const out = (r.choices?.[0]?.message?.content || '').trim();
+            const cleaned = out.replace(/\s+$/g, '');
+            const limited = cleaned.length > maxChars ? cleaned.slice(0, maxChars) + '…' : cleaned;
+            this.logger.log(
+                `summarizeJobPost 완료: len=${limited.length}, durationMs=${Date.now() - t0}`,
+            );
+            return limited;
+        } catch (e: any) {
+            this.logger.warn(`summarizeJobPost 실패: ${e?.message}`);
+            const truncated = raw.replace(/\s+/g, ' ').trim();
+            return truncated.length > maxChars ? truncated.slice(0, maxChars) + '…' : truncated;
+        }
+    }
+
+    // Basic URL validation + SSRF guard (best-effort)
+    private validateUrl(urlStr: string): { ok: boolean; error?: string } {
+        try {
+            const u = new URL(urlStr);
+            if (!['http:', 'https:'].includes(u.protocol)) {
+                return { ok: false, error: 'http/https만 허용됩니다.' };
+            }
+            const host = u.hostname.toLowerCase();
+            const blocked = ['localhost', '127.0.0.1', '0.0.0.0', '::1'];
+            if (blocked.includes(host) || host.endsWith('.local')) {
+                return { ok: false, error: '로컬 주소는 허용되지 않습니다.' };
+            }
+            // Note: 완전한 SSRF 방지는 DNS/IP 해석이 필요하므로 여기서는 기본 차단만 수행
+            return { ok: true };
+        } catch {
+            return { ok: false, error: '유효하지 않은 URL입니다.' };
+        }
+    }
+
+    private buildBrowserHeaders(urlStr: string, kind: 'html' | 'image') {
+        let origin = '';
+        try {
+            const u = new URL(urlStr);
+            origin = `${u.protocol}//${u.host}`;
+        } catch {}
+        const common: Record<string, string> = {
+            'User-Agent':
+                'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36',
+            'Accept-Language': 'ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7',
+            Referer: origin || 'https://www.google.com/',
+            'Cache-Control': 'no-cache',
+        };
+        if (kind === 'html') {
+            return {
+                ...common,
+                Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8',
+                'Sec-Fetch-Site': 'none',
+                'Sec-Fetch-Mode': 'navigate',
+                'Sec-Fetch-Dest': 'document',
+                'Upgrade-Insecure-Requests': '1',
+            } as Record<string, string>;
+        }
+        return {
+            ...common,
+            Accept: 'image/avif,image/webp,image/png,image/*,*/*;q=0.8',
+            'Sec-Fetch-Site': 'same-origin',
+            'Sec-Fetch-Mode': 'no-cors',
+            'Sec-Fetch-Dest': 'image',
+        } as Record<string, string>;
+    }
+
+    private async fetchHtml(urlStr: string): Promise<{ html: string; finalUrl?: string }> {
+        const controller = new AbortController();
+        const timeout = setTimeout(() => controller.abort(), 8000);
+        try {
+            const primaryHeaders = this.buildBrowserHeaders(urlStr, 'html');
+            let res = await fetch(urlStr, {
+                method: 'GET',
+                redirect: 'follow',
+                signal: controller.signal,
+                headers: primaryHeaders as any,
+            } as any);
+            // Retry with alternate UA if blocked
+            if (!res.ok && (res.status === 403 || res.status === 406)) {
+                const altHeaders = {
+                    ...primaryHeaders,
+                    'User-Agent':
+                        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36',
+                };
+                res = await fetch(urlStr, {
+                    method: 'GET',
+                    redirect: 'follow',
+                    signal: controller.signal,
+                    headers: altHeaders as any,
+                } as any);
+            }
+            if (!res.ok) throw new Error(`HTTP ${res.status}`);
+            const html = await res.text();
+            const finalUrl = (res as any).url || urlStr;
+            return { html, finalUrl };
+        } catch (e: any) {
+            throw new Error(`페이지 로드 실패: ${e?.message || e}`);
+        } finally {
+            clearTimeout(timeout);
+        }
+    }
+
+    private extractMeta(html: string): Record<string, string> {
+        const meta: Record<string, string> = {};
+        const titleMatch = html.match(/<title[^>]*>([\s\S]*?)<\/title>/i);
+        if (titleMatch) meta.title = this.clean(titleMatch[1]);
+
+        const metaTagRe =
+            /<meta[^>]+(name|property)=["']([^"']+)["'][^>]*content=["']([^"']+)["'][^>]*>/gi;
+        let m: RegExpExecArray | null;
+        while ((m = metaTagRe.exec(html))) {
+            const key = m[2].toLowerCase();
+            meta[key] = this.clean(m[3]);
+        }
+        return meta;
+    }
+
+    private extractMainText(html: string): string {
+        // Remove scripts/styles
+        let body = html
+            .replace(/<script[\s\S]*?<\/script>/gi, '')
+            .replace(/<style[\s\S]*?<\/style>/gi, '');
+        // Get body content
+        const bodyMatch = body.match(/<body[^>]*>([\s\S]*?)<\/body>/i);
+        body = bodyMatch ? bodyMatch[1] : body;
+        // Strip tags
+        const text = body
+            .replace(/<[^>]+>/g, '\n')
+            .replace(/&nbsp;/g, ' ')
+            .replace(/&amp;/g, '&')
+            .replace(/&lt;/g, '<')
+            .replace(/&gt;/g, '>');
+        // Collapse whitespace
+        return text
+            .split('\n')
+            .map((t) => t.trim())
+            .filter((t) => t.length > 0)
+            .join('\n');
+    }
+
+    private extractImageUrls(html: string, baseUrl: string): string[] {
+        const urls = new Set<string>();
+        const re = /<img[^>]+(src|data-src|data-original|data-lazy)=["']([^"']+)["'][^>]*>/gi;
+        let m: RegExpExecArray | null;
+        while ((m = re.exec(html))) {
+            const raw = m[2];
+            try {
+                const u = new URL(raw, baseUrl).toString();
+                // Filter suspicious/very small images by extension heuristic
+                if (/(\.png|\.jpe?g|\.webp|\.gif)(\?|$)/i.test(u)) {
+                    urls.add(u);
+                }
+            } catch {
+                // ignore
+            }
+        }
+        return Array.from(urls);
+    }
+
+    private async ocrImages(imageUrls: string[]): Promise<string> {
+        if (!imageUrls.length) return '';
+
+        const maxParallel = 2;
+        const texts: string[] = [];
+        let i = 0;
+        const worker = async () => {
+            while (i < imageUrls.length) {
+                const idx = i++;
+                const url = imageUrls[idx];
+                try {
+                    const buffer = await this.fetchImage(url);
+                    if (!buffer || buffer.length === 0) continue;
+                    const [result] = await this.vision.textDetection({
+                        image: { content: buffer },
+                    });
+                    const fullText = result.fullTextAnnotation?.text || '';
+                    if (fullText && fullText.trim()) texts.push(fullText.trim());
+                } catch (e: any) {
+                    this.logger.warn(`OCR 실패: ${url} - ${e?.message || e}`);
+                }
+            }
+        };
+        await Promise.all(Array.from({ length: Math.min(maxParallel, imageUrls.length) }, worker));
+        return texts
+            .map((t) => t.replace(/\r/g, '').trim())
+            .filter(Boolean)
+            .join('\n');
+    }
+
+    private async fetchImage(urlStr: string): Promise<Buffer> {
+        const controller = new AbortController();
+        const timeout = setTimeout(() => controller.abort(), 8000);
+        try {
+            const headers = this.buildBrowserHeaders(urlStr, 'image');
+            const res = await fetch(urlStr, {
+                method: 'GET',
+                signal: controller.signal,
+                headers: headers as any,
+            } as any);
+            if (!res.ok) throw new Error(`HTTP ${res.status}`);
+            const ab = await res.arrayBuffer();
+            return Buffer.from(ab);
+        } catch (e: any) {
+            throw new Error(`이미지 로드 실패: ${e?.message || e}`);
+        } finally {
+            clearTimeout(timeout);
+        }
+    }
+
+    private clean(s: string): string {
+        return (s || '').replace(/\s+/g, ' ').trim();
+    }
+
+    private isTextInsufficient(text: string): boolean {
+        if (!text) return true;
+        // Heuristic: too short or lacks typical job keywords
+        if (text.length < 500) return true;
+        const kw = [
+            '담당',
+            '업무',
+            '담당업무',
+            '주요',
+            '자격',
+            '필수',
+            '요건',
+            '채용',
+            '전형',
+            '지원',
+            '우대',
+            '서류',
+            '면접',
+            '주요업무',
+            '자격요건',
+            '필수요건',
+            '우대사항',
+            '근무지',
+            '근무형태',
+            '연봉',
+            'Responsibilities',
+            'Qualifications',
+            'Preferred',
+            'Benefits',
+        ];
+        const lc = text.toLowerCase();
+        const hit = kw.some((k) => lc.includes(k.toLowerCase()));
+        return !hit;
+    }
+
+    private mergeContents(htmlText: string, ocrText: string): string {
+        const parts = [htmlText?.trim(), ocrText?.trim()].filter((t) => t && t.length > 0);
+        // Deduplicate simple lines
+        const seen = new Set<string>();
+        const lines: string[] = [];
+        for (const p of parts) {
+            for (const line of p.split(/\n+/)) {
+                const norm = line.replace(/\s+/g, ' ').trim();
+                if (norm && !seen.has(norm)) {
+                    seen.add(norm);
+                    lines.push(norm);
+                }
+            }
+        }
+        return lines.join('\n');
+    }
+
+    private guessCompany(meta: Record<string, string>, text: string): string {
+        // Try meta first
+        const ogSite = meta['og:site_name'] || meta['application-name'];
+        if (ogSite) return this.clean(ogSite);
+        // Try simple pattern in text
+        const m = text.match(/회사명\s*[:\-]\s*([^\n]{1,50})/);
+        return m ? this.clean(m[1]) : '';
+    }
+}


### PR DESCRIPTION
- 채용공고 url에서 내용을 파싱하고, OpenAI LLM을 이용해 요약하여 질문 생성 로직에 반영합니다.
- 사람인 url은 기본적으로 가능하며, html fetch를 막아놓은 사이트의 경우 playwright 패키지를 이용한 우회가 가능합니다.
   (넥슨 커리어 사이트의 우회 파싱이 가능함을 확인했습니다)
- 직군이 섞여 있는 공고의 경우 사용자가 원하는 직무를 찾기 어려울 수 있습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 채용공고 URL에서 내용·제목·회사 정보를 추출하고 요약을 제공하는 API 추가, 세션별 컨텍스트 저장 지원.
  - 이력서 요약과 채용공고 컨텍스트를 결합해 인터뷰 질문·후속 질문의 정확성과 관련성 향상.
- 유지보수/작업
  - 데이터 정리 스크립트 추가(일반 실행 및 드라이런).
  - OCR 및 동적 렌더링 지원을 위한 런타임 의존성 추가.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->