### PR TITLE
[ feat ] mentoring info 섹션 제거

### DIFF
--- a/src/modules/mentoring/dto/product-list.dto.ts
+++ b/src/modules/mentoring/dto/product-list.dto.ts
@@ -5,7 +5,6 @@ export class MentoringProductListItemDto {
         nickname: string;
         profile: string;
         profile_img: string;
-        info: string[];
     };
     rating: number;
     participants: number;

--- a/src/modules/mentoring/mentoring.service.ts
+++ b/src/modules/mentoring/mentoring.service.ts
@@ -1264,7 +1264,6 @@ export class MentoringService {
                     nickname: row.mentor_nickname,
                     profile: row.description, // 멘토링 상품 설명으로 변경
                     profile_img: row.profile_img || 'https://picsum.photos/200?3',
-                    info: [row.description], // 멘토링 상품 설명을 info 배열에 포함
                 },
                 rating: row.rating,
                 participants: row.participants,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - 멘토링 상품 목록의 멘토 카드에서 ‘추가 정보’(info) 배열 표시를 제거했습니다. 이제 목록에서는 닉네임, 프로필, 평점, 참여자 수, 가격 등 핵심 정보만 노출됩니다.
  - 일부 화면에서 더 간결하고 집중된 목록 경험을 제공합니다. 기존에 info 기반으로 표시되던 부가 텍스트는 더 이상 보이지 않으며, API 응답에서도 동일하게 제외되어 일관성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->