### PR TITLE
[ fix ] interview_sessions 테이블에 ended_at, external_key 추가, interview_reports 테이블에 user_id 저장

### DIFF
--- a/sql/interview.sql
+++ b/sql/interview.sql
@@ -3,10 +3,11 @@ USE `new-good-job-test`;
 CREATE TABLE IF NOT EXISTS interview_sessions (
   session_id      VARCHAR(64) PRIMARY KEY,
   user_id         INT NOT NULL,
-  external_key    VARCHAR(128) UNIQUE NULL,
+  external_key    VARCHAR(64) NULL COMMENT 'resume_files.id 참조(비고유)',
   created_at      TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
   ended_at        TIMESTAMP NULL,
   INDEX idx_sessions_user_created (user_id, created_at),
+  INDEX idx_sessions_external_key (external_key),
   CONSTRAINT fk_sessions_user FOREIGN KEY (user_id) REFERENCES users(idx) ON DELETE RESTRICT
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 

--- a/sql/interview.sql
+++ b/sql/interview.sql
@@ -109,12 +109,15 @@ CREATE TABLE IF NOT EXISTS audio_metrics_question (
 -- 분석 결과 리포트 저장(선택)
 CREATE TABLE IF NOT EXISTS interview_reports (
   session_id     VARCHAR(64) PRIMARY KEY,
+  user_id        INT NOT NULL,
   overall_score  INT NOT NULL,
   question_count INT NOT NULL,
   payload        JSON NOT NULL,
   created_at     TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
   updated_at     TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-  CONSTRAINT fk_ir_session FOREIGN KEY (session_id) REFERENCES interview_sessions(session_id) ON DELETE CASCADE
+  CONSTRAINT fk_ir_session FOREIGN KEY (session_id) REFERENCES interview_sessions(session_id) ON DELETE CASCADE,
+  CONSTRAINT fk_ir_user FOREIGN KEY (user_id) REFERENCES users(idx) ON DELETE RESTRICT,
+  INDEX idx_ir_user_created (user_id, created_at)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- -- Indexes for faster listing/filtering

--- a/src/modules/interview/interview.controller.ts
+++ b/src/modules/interview/interview.controller.ts
@@ -1,5 +1,14 @@
 // src/modules/interview/interview.controller.ts
-import { BadRequestException, Body, Controller, Post, Req, Param, Logger, Get } from '@nestjs/common';
+import {
+    BadRequestException,
+    Body,
+    Controller,
+    Post,
+    Req,
+    Param,
+    Logger,
+    Get,
+} from '@nestjs/common';
 import { ResumeFileService } from '@/modules/resume-file/resume-file.service';
 import { z } from 'zod';
 import {
@@ -267,8 +276,8 @@ export class AiController {
             return { ok: true, exists: false, hasReport: false };
         }
         const rep = await this.db.query<{ c: number }>(
-            `SELECT COUNT(*) AS c FROM interview_reports WHERE session_id = ?`,
-            [sessionId],
+            `SELECT COUNT(*) AS c FROM interview_reports WHERE session_id = ? AND user_id = ?`,
+            [sessionId, userId],
         );
         return {
             ok: true,
@@ -284,7 +293,11 @@ export class AiController {
      * - 리포트가 이미 생성된 세션은 삭제하지 않고 종료만 표시
      */
     @Post(':sessionId/cancel')
-    async cancelSession(@Param('sessionId') sessionId: string, @Req() req: any, @Body() _body?: any) {
+    async cancelSession(
+        @Param('sessionId') sessionId: string,
+        @Req() req: any,
+        @Body() _body?: any,
+    ) {
         this.logger.log(`POST /ai/${sessionId}/cancel`);
         const userId = Number(req?.user_idx ?? req?.user?.idx);
         if (!userId) throw new BadRequestException('unauthorized');
@@ -305,8 +318,8 @@ export class AiController {
 
         // 이미 리포트가 생성된 경우 삭제하지 않음
         const rep = await this.db.query<{ c: number }>(
-            `SELECT COUNT(*) AS c FROM interview_reports WHERE session_id = ?`,
-            [sessionId],
+            `SELECT COUNT(*) AS c FROM interview_reports WHERE session_id = ? AND user_id = ?`,
+            [sessionId, userId],
         );
         if ((rep[0]?.c || 0) > 0) {
             await this.db.execute(

--- a/src/modules/report/report.service.ts
+++ b/src/modules/report/report.service.ts
@@ -35,14 +35,26 @@ export class ReportService {
     async saveReport(sessionId: string, payload: InterviewAnalysisResult): Promise<void> {
         const overallScore = payload.overall_score ?? 0;
 
+        // 세션에서 user_id 조회 후 보고서에 함께 저장
+        const sessRows = await this.db.query<{ user_id: number }>(
+            `SELECT user_id FROM interview_sessions WHERE session_id = ?`,
+            [sessionId],
+        );
+        const userId = sessRows[0]?.user_id;
+        if (!userId) {
+            // 세션이 없으면 저장하지 않음 (무결성 보장)
+            return;
+        }
+
         await this.db.execute(
-            `INSERT INTO interview_reports (session_id, overall_score, question_count, payload)
-             VALUES (?, ?, ?, ?)
+            `INSERT INTO interview_reports (session_id, user_id, overall_score, question_count, payload)
+             VALUES (?, ?, ?, ?, ?)
              ON DUPLICATE KEY UPDATE 
+               user_id=VALUES(user_id),
                overall_score=VALUES(overall_score), 
                question_count=VALUES(question_count), 
                payload=VALUES(payload)`,
-            [sessionId, overallScore, 0, JSON.stringify(payload)],
+            [sessionId, userId, overallScore, 0, JSON.stringify(payload)],
         );
     }
 
@@ -291,8 +303,7 @@ export class ReportService {
         }>(
             `SELECT r.session_id, r.overall_score, r.question_count, r.created_at
              FROM interview_reports r
-             JOIN interview_sessions s ON s.session_id = r.session_id
-             WHERE s.user_id = ?
+             WHERE r.user_id = ?
              ORDER BY r.created_at DESC
              LIMIT ? OFFSET ?`,
             [userId, limit, offset],

--- a/src/modules/report/report.service.ts
+++ b/src/modules/report/report.service.ts
@@ -56,6 +56,12 @@ export class ReportService {
                payload=VALUES(payload)`,
             [sessionId, userId, overallScore, 0, JSON.stringify(payload)],
         );
+
+        // 리포트 발행 시점에 세션 종료 시간 기록(최초 1회만)
+        await this.db.execute(
+            `UPDATE interview_sessions SET ended_at = COALESCE(ended_at, NOW()) WHERE session_id = ?`,
+            [sessionId],
+        );
     }
 
     // ===== Public API =====


### PR DESCRIPTION
-  interview_reports 테이블에 user_id를 저장하도록 수정했습니다. (마이페이지 리포트 다시보기 구현용)
-  interview_sessions 테이블에 ended_at, external_key가 추가되었습니다. (external_key에는 이력서 파일 id 저장)