### PR TITLE
[feat] 정기 슬롯 API에 예약 상태 필드 추가

### DIFF
--- a/src/modules/mentoring/dto/product-regular-slots.dto.ts
+++ b/src/modules/mentoring/dto/product-regular-slots.dto.ts
@@ -3,6 +3,7 @@ export class ProductRegularSlotItemDto {
     day_of_week: number; // 1-7
     hour_slot: number; // 0-23
     time_range: string; // HH:00-(HH+1):00
+    is_booked: boolean; // 예약 여부
 }
 
 export class ProductRegularSlotsResponseDto {

--- a/src/modules/mentoring/mentoring.service.ts
+++ b/src/modules/mentoring/mentoring.service.ts
@@ -320,7 +320,6 @@ export class MentoringService {
             available: Number(r.reserved_count ?? 0) === 0,
         }));
 
-        // 가능한(예약되지 않은) 정기 슬롯만 반환
         const slots = slotsAll.filter((s) => s.available);
 
         return {
@@ -332,15 +331,27 @@ export class MentoringService {
 
     async getProductRegularSlots(productIdx: number): Promise<ProductRegularSlotsResponseDto> {
         const sql = `
-            SELECT regular_slots_idx, day_of_week, hour_slot
-              FROM mentoring_regular_slots
-             WHERE product_idx = ?
-             ORDER BY day_of_week, hour_slot
+            SELECT 
+                s.regular_slots_idx, 
+                s.day_of_week, 
+                s.hour_slot,
+                CASE 
+                    WHEN COUNT(a.application_id) > 0 THEN 1 
+                    ELSE 0 
+                END AS is_booked
+              FROM mentoring_regular_slots s
+              LEFT JOIN mentoring_applications a 
+                ON s.regular_slots_idx = a.regular_slots_idx
+               AND a.application_status IN ('pending', 'approved', 'completed')
+             WHERE s.product_idx = ?
+             GROUP BY s.regular_slots_idx, s.day_of_week, s.hour_slot
+             ORDER BY s.day_of_week, s.hour_slot
         `;
         const rows = await this.databaseService.query<{
             regular_slots_idx: number;
             day_of_week: number;
             hour_slot: number;
+            is_booked: number;
         }>(sql, [productIdx]);
 
         const slots = rows.map((r) => ({
@@ -348,6 +359,7 @@ export class MentoringService {
             day_of_week: Number(r.day_of_week),
             hour_slot: Number(r.hour_slot),
             time_range: `${String(r.hour_slot).padStart(2, '0')}:00-${String(r.hour_slot + 1).padStart(2, '0')}:00`,
+            is_booked: Number(r.is_booked) === 1,
         }));
 
         return { product_idx: productIdx, slots };


### PR DESCRIPTION
- ProductRegularSlotItemDto에 is_booked 필드 추가
- getProductRegularSlots에서 예약 상태 확인 로직 구현
- pending/approved/completed 상태를 예약됨으로 처리

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 멘토링 상품의 슬롯 목록에 “예약됨/예약 가능” 상태가 표시됩니다.
  - 정기 슬롯과 날짜별 슬롯 모두에서 각 시간대의 예약 여부를 한눈에 확인할 수 있어, 가용 시간 선택이 더 쉬워졌습니다.
  - 슬롯 선택 시 이미 예약된 시간대를 피하고, 가능한 시간대를 신속히 찾을 수 있도록 UI에 예약 상태가 반영됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->