### PR TITLE
feat: 캔버스 종료 시간을 24시간 이후로 변경함

### DIFF
--- a/src/modules/coaching-resume/canvas.service.ts
+++ b/src/modules/coaching-resume/canvas.service.ts
@@ -172,7 +172,7 @@ export class CanvasService {
             TIMESTAMP(
                 a.booked_date,
                 MAKETIME(rs.hour_slot, 0, 0)
-            ) + INTERVAL 12 HOUR AS end_time
+            ) + INTERVAL 24 HOUR AS end_time
         FROM canvas c
         JOIN mentoring_applications a ON a.application_id = c.application_id
         JOIN mentoring_regular_slots rs ON a.regular_slots_idx = rs.regular_slots_idx

--- a/src/modules/mentoring/mentoring.service.ts
+++ b/src/modules/mentoring/mentoring.service.ts
@@ -1047,7 +1047,7 @@ export class MentoringService {
             TIMESTAMP(
                 a.booked_date,
                 MAKETIME(rs.hour_slot, 0, 0)
-            ) + INTERVAL 12 HOUR AS end_time
+            ) + INTERVAL 24 HOUR AS end_time
         FROM mentoring_applications a
         JOIN users u ON a.mentee_idx = u.idx
         LEFT JOIN mentoring_products p ON a.product_idx = p.product_idx


### PR DESCRIPTION
ㅈㄱㄴ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 코칭 이력 캔버스 상세에서 세션 종료 시간 계산을 12시간에서 24시간으로 반영해 일정 표시 정확도 개선.
  - 멘토링 신청 내역에서도 종료 시간 계산을 24시간 기준으로 통일하여 목록/상세의 가용 시간 및 기간 표시 일관성 향상.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->