### PR TITLE
fix:화자분리 기능 및 긴글 자르는 로직 제거 & WebRTC60분 제한 주석처리

### DIFF
--- a/src/modules/collab/collab.gateway.ts
+++ b/src/modules/collab/collab.gateway.ts
@@ -218,12 +218,12 @@ export class CollabGateway implements OnGatewayInit, OnGatewayConnection, OnGate
         }
 
         // 세션 종료 시간이 이미 지났으면 안내 후 종료
-        const endMs = await this.getSessionEndTime(room);
-        if (endMs && endMs - Date.now() <= 0) {
-            client.emit('session-ended');
-            console.log(`⛔ join denied, session already ended: ${room}`);
-            return;
-        }
+        // const endMs = await this.getSessionEndTime(room);
+        // if (endMs && endMs - Date.now() <= 0) {
+        //     client.emit('session-ended');
+        //     console.log(`⛔ join denied, session already ended: ${room}`);
+        //     return;
+        // }
 
         client.join(room);
 
@@ -232,7 +232,7 @@ export class CollabGateway implements OnGatewayInit, OnGatewayConnection, OnGate
         console.log(`🚀 [joinCanvas] sending init size=${init.length}`);
         client.emit('init', Array.from(init));
 
-        await this.scheduleRoomShutdown(room);
+        // await this.scheduleRoomShutdown(room);
 
         console.log(`📌 (Canvas) ${client.id} joined ${room}`);
     }

--- a/src/stt/providers/google-speech.ts
+++ b/src/stt/providers/google-speech.ts
@@ -247,14 +247,11 @@ export class GoogleSpeechProvider implements SpeechProvider {
     private processWordTimings(words: GoogleSpeechWord[]): SpeakerSegment[] {
         if (!words || words.length === 0) return [];
 
-        // 🆕 개선된 화자 분리 로직
         const segments: SpeakerSegment[] = [];
         let currentSegment: SpeakerSegment | null = null;
-        const minSegmentDuration = 0.5; // 최소 0.5초 세그먼트
-        const maxSegmentDuration = 3.0; // 최대 10초 세그먼트
-
-        // 🆕 추가: 문장 길이 기반 분할
-        const maxTextLength = 30; // 최대 30자
+        const minSegmentDuration = 0.2;
+        const maxSegmentDuration = 10.0;
+        const maxTextLength = 100;
 
         for (let i = 0; i < words.length; i++) {
             const word = words[i];
@@ -264,20 +261,21 @@ export class GoogleSpeechProvider implements SpeechProvider {
 
             const startTime = this.convertDurationToSeconds(word.startTime);
             const endTime = this.convertDurationToSeconds(word.endTime);
-            const speakerTag = word.speakerTag ?? 0;
+            const speakerTag = 1; // 모든 세그먼트를 화자 1로 고정
 
-            // 화자 변경 감지
-            const isSpeakerChange = currentSegment && currentSegment.speakerTag !== speakerTag;
+            // 화자 변경 감지 제거
+            // const isSpeakerChange = false;
 
             // 세그먼트가 너무 길어지면 강제 분할 (시간 기준)
             const isTooLong =
                 currentSegment && startTime - currentSegment.startTime > maxSegmentDuration;
 
-            // 🆕 세그먼트가 너무 길어지면 강제 분할 (텍스트 길이 기준)
+            // 세그먼트가 너무 길어지면 강제 분할 (텍스트 길이 기준)
             const isTextTooLong =
                 currentSegment && currentSegment.text_Content.length > maxTextLength;
 
-            if (isSpeakerChange || isTooLong || isTextTooLong) {
+            if (isTooLong || isTextTooLong) {
+                // 화자 변경 조건 제거
                 if (currentSegment) {
                     if (currentSegment.endTime - currentSegment.startTime >= minSegmentDuration) {
                         segments.push(currentSegment);
@@ -288,7 +286,7 @@ export class GoogleSpeechProvider implements SpeechProvider {
                     text_Content: cleanedText,
                     startTime: Math.round(startTime * 10) / 10,
                     endTime: Math.round(endTime * 10) / 10,
-                    speakerTag: speakerTag,
+                    speakerTag: speakerTag, // 항상 1
                 };
             } else {
                 if (currentSegment) {
@@ -301,7 +299,7 @@ export class GoogleSpeechProvider implements SpeechProvider {
                         text_Content: cleanedText,
                         startTime: Math.round(startTime * 10) / 10,
                         endTime: Math.round(endTime * 10) / 10,
-                        speakerTag: speakerTag,
+                        speakerTag: speakerTag, // 항상 1
                     };
                 }
             }
@@ -315,7 +313,6 @@ export class GoogleSpeechProvider implements SpeechProvider {
             segments.push(currentSegment);
         }
 
-        // 🆕 세그먼트 후처리
         return this.postProcessSegments(segments);
     }
 

--- a/src/stt/services/audio-chunk-processor.service.ts
+++ b/src/stt/services/audio-chunk-processor.service.ts
@@ -1,10 +1,7 @@
 // 파일 상단에 추가
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+
 /* eslint-disable @typescript-eslint/no-unsafe-return */
-/* eslint-disable @typescript-eslint/no-unsafe-call */
-/* eslint-disable @typescript-eslint/no-unsafe-argument */
-/* eslint-disable @typescript-eslint/no-unsafe-enum-comparison */
+
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import { Injectable, Logger } from '@nestjs/common';
@@ -18,7 +15,6 @@ import { STTSessionService } from './stt-seesion.service';
 import { GcsService } from '../../lib/gcs';
 import { AudioDurationService } from './audio-duration.service';
 import { STTUtilService } from './stt-util.service';
-import { TimeCheckResult } from './session-timer.service';
 import { STTResult } from '../entities/transcription';
 
 // 세션 데이터 타입 확장
@@ -47,7 +43,6 @@ export class AudioChunkProcessorService {
         actualMenteeIdx: number,
         usePynoteDiarization: boolean,
         startTime: number,
-        timeCheck: TimeCheckResult,
     ): Promise<STTWithContextResponse> {
         const audioBuffer = Buffer.from(audioData, 'base64');
 
@@ -146,7 +141,6 @@ export class AudioChunkProcessorService {
                 actualMentorIdx,
                 actualMenteeIdx,
                 canvasId,
-                timeCheck,
                 startTime,
             );
         } catch (error) {
@@ -258,7 +252,6 @@ export class AudioChunkProcessorService {
         mentorIdx: number,
         menteeIdx: number,
         canvasId: string,
-        timeCheck: TimeCheckResult,
         startTime: number,
     ): STTWithContextResponse {
         return {
@@ -279,15 +272,6 @@ export class AudioChunkProcessorService {
             mentee_idx: menteeIdx,
             speakerInfo: { mentor: '', mentee: '' },
             canvasId: canvasId,
-            sessionTimeInfo: timeCheck.timeInfo,
-            timeWarning: timeCheck.shouldWarn
-                ? {
-                      level:
-                          timeCheck.timeInfo.warningLevel === 'critical' ? 'critical' : 'warning',
-                      message: timeCheck.message,
-                      remainingMinutes: timeCheck.timeInfo.remainingMinutes,
-                  }
-                : undefined,
         };
     }
 }

--- a/src/stt/services/transcribe-context.use-case.ts
+++ b/src/stt/services/transcribe-context.use-case.ts
@@ -1,16 +1,8 @@
 // 파일 상단에 추가
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
-/* eslint-disable @typescript-eslint/no-unsafe-return */
-/* eslint-disable @typescript-eslint/no-unsafe-call */
-/* eslint-disable @typescript-eslint/no-unsafe-argument */
-/* eslint-disable @typescript-eslint/no-unsafe-enum-comparison */
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
 
 import { Injectable, BadRequestException } from '@nestjs/common';
 import { TranscribeChunkRequest, STTWithContextResponse } from '../entities/transcription';
-import { SessionTimerService } from './session-timer.service';
+// import { SessionTimerService } from './session-timer.service';
 import { DatabaseService } from '../../database/database.service';
 import { STTUtilService } from './stt-util.service';
 import { AudioChunkProcessorService } from './audio-chunk-processor.service';
@@ -19,7 +11,6 @@ import { SessionFinalizerService } from './session-finalizer.service';
 @Injectable()
 export class TranscribeContextUseCase {
     constructor(
-        private readonly sessionTimerService: SessionTimerService,
         private readonly databaseService: DatabaseService,
         private readonly utilService: STTUtilService,
         private readonly audioChunkProcessor: AudioChunkProcessorService,
@@ -29,12 +20,6 @@ export class TranscribeContextUseCase {
     async execute(body: TranscribeChunkRequest): Promise<STTWithContextResponse> {
         // 1. 유효성 검증
         this.validateRequest(body);
-
-        // 2. 시간 제한 확인
-        const timeCheck = this.sessionTimerService.checkTimeLimit(body.canvasId);
-        if (!timeCheck.allowed) {
-            throw new BadRequestException(timeCheck.message);
-        }
 
         // 3. 참가자 정보 조회
         const participants = await this.getParticipants(body.canvasId);
@@ -54,7 +39,6 @@ export class TranscribeContextUseCase {
                 actualMenteeIdx,
                 body.usePynoteDiarization ?? true,
                 startTime,
-                timeCheck,
             );
 
             // 최종 청크일 때만 병합

--- a/src/stt/stt_controller.ts
+++ b/src/stt/stt_controller.ts
@@ -29,7 +29,6 @@ import { STTMessageService } from './services/stt-message.service';
 import { STTUtilService } from './services/stt-util.service';
 import { AudioProcessorUtil } from './utils/audio-processer';
 import { AudioDurationService } from './services/audio-duration.service';
-import { SessionTimerService } from './services/session-timer.service';
 import { TranscribeContextUseCase } from './services/transcribe-context.use-case';
 
 @ApiTags('Speech-to-Text')
@@ -45,7 +44,6 @@ export class STTController {
         private readonly messageService: STTMessageService,
         private readonly utilService: STTUtilService,
         private readonly audioDurationService: AudioDurationService,
-        private readonly sessionTimerService: SessionTimerService,
         private readonly transcribeUseCase: TranscribeContextUseCase,
     ) {}
 

--- a/src/stt/stt_module.ts
+++ b/src/stt/stt_module.ts
@@ -9,7 +9,6 @@ import { DatabaseModule } from '../database/database.module';
 import { AudioDurationService } from './services/audio-duration.service';
 import { GcsService } from '../lib/gcs';
 import { PynoteService } from './providers/pynote.service';
-import { SessionTimerService } from './services/session-timer.service';
 import { TranscribeContextUseCase } from './services/transcribe-context.use-case';
 import { AudioChunkProcessorService } from './services/audio-chunk-processor.service';
 import { SessionFinalizerService } from './services/session-finalizer.service';
@@ -26,7 +25,6 @@ import { SessionFinalizerService } from './services/session-finalizer.service';
         AudioDurationService,
         GcsService,
         PynoteService,
-        SessionTimerService,
         TranscribeContextUseCase,
         AudioChunkProcessorService,
         SessionFinalizerService,

--- a/src/stt/utils/text_processor.ts
+++ b/src/stt/utils/text_processor.ts
@@ -146,7 +146,7 @@ export class TextProcessorUtil {
         // 2. 문장 끝으로 분리되지 않은 경우, 의미 단위로 분리
         const finalSentences: string[] = [];
         for (const sentence of sentences) {
-            if (sentence.length <= 100) {
+            if (sentence.length <= 500) {
                 // 100자 이하면 그대로 유지
                 finalSentences.push(sentence);
             } else {
@@ -190,7 +190,7 @@ export class TextProcessorUtil {
         const sentences: string[] = [];
         let remainingText = text.trim();
 
-        while (remainingText.length > 100) {
+        while (remainingText.length > 500) {
             // 100자보다 길면 분할
             let bestSplitIndex = -1;
             let bestBreak = '';
@@ -198,7 +198,7 @@ export class TextProcessorUtil {
             // 뒤에서부터 의미 있는 분할점 찾기
             for (const breakPoint of meaningfulBreaks) {
                 const lastIndex = remainingText.lastIndexOf(breakPoint, 100);
-                if (lastIndex > bestSplitIndex && lastIndex > 20) {
+                if (lastIndex > bestSplitIndex && lastIndex > 100) {
                     // 최소 20자 이상 유지
                     bestSplitIndex = lastIndex;
                     bestBreak = breakPoint;
@@ -216,7 +216,7 @@ export class TextProcessorUtil {
             } else {
                 // 의미 있는 분할점이 없으면 100자에서 강제 분할
                 sentences.push(remainingText.substring(0, 100).trim());
-                remainingText = remainingText.substring(100).trim();
+                remainingText = remainingText.substring(300).trim();
             }
         }
 
@@ -241,7 +241,7 @@ export class TextProcessorUtil {
         processed = this.resolveSpeakerOverlaps(processed);
 
         // 🆕 긴 문장 분리 적용
-        processed = this.splitLongSentences(processed);
+        // processed = this.splitLongSentences(processed);
 
         return processed;
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선**
  * 콜라보 캔버스 참여 시 세션 종료 시간 검증과 자동 종료 예약을 비활성화하여 참여가 차단되지 않습니다.
  * 음성 인식(STT)에서 화자 분리 감지를 중단하고 단일 화자 기준으로 더 긴 세그먼트를 생성합니다(최대 10초, 텍스트 길이 상향).
  * 긴 문장 자동 분할을 완화하여 더 긴 텍스트가 유지됩니다.
* **기타**
  * 세션 시간 제한 관련 경고/정보가 더 이상 반환되지 않습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->